### PR TITLE
Overhauls module handling for Terraform generation

### DIFF
--- a/examples/common-services.yaml
+++ b/examples/common-services.yaml
@@ -9,6 +9,11 @@ spec:
     - github.com/cloud-native-toolkit/terraform-ibm-object-storage
     - github.com/cloud-native-toolkit/terraform-ibm-key-protect
     - github.com/cloud-native-toolkit/terraform-ibm-logdna
-    - github.com/cloud-native-toolkit/terraform-ibm-vpc
     - github.com/cloud-native-toolkit/terraform-ibm-sysdig
-  variables: []
+    - github.com/cloud-native-toolkit/terraform-ibm-scc-collector
+  variables:
+    - name: resource_group_name
+    - name: region
+    - name: ibmcloud_api_key
+    - name: name_prefix
+    - name: scc_registration_key

--- a/examples/ocp-management.yaml
+++ b/examples/ocp-management.yaml
@@ -1,0 +1,59 @@
+apiVersion: cloud.ibm.com/v1alpha1
+kind: BillOfMaterial
+metadata:
+  name: ocp-management
+spec:
+  modules:
+    - name: ibm-vpc
+    - name: ibm-vpc-gateways
+    - name: ibm-vpc-subnets
+      alias: cluster-subnets
+      variables:
+        - name: subnet_count
+          value: 3
+        - name: subnet_label
+          value: cluster
+    - name: ibm-ocp-vpc
+      dependencies:
+        - name: subnets
+          ref: cluster-subnets
+    - name: ibm-vpc-subnets
+      alias: bastion-subnets
+      variables:
+        - name: subnet_count
+          value: 2
+        - name: subnet_label
+          value: bastion
+    - name: vsi-bastion
+      dependencies:
+        - name: subnets
+          ref: bastion-subnets
+    - name: namespace
+      variables:
+        - name: name
+          value: tools
+    - name: namespace
+      alias: argocd-namespace
+      variables:
+        - name: name
+          value: argocd
+    - name: ibm-image-registry
+    - name: ibm-logdna-bind
+    - name: ibm-sysdig-bind
+    - name: argocd
+      dependencies:
+        - name: namespace
+          ref: argocd-namespace
+    - name: dashboard
+    - name: pactbroker
+    - name: artifactory
+    - name: swaggereditor
+    - name: sonarqube
+    - name: tekton
+    - name: resources
+    - name: source-control
+  variables:
+    - name: resource_group_name
+    - name: region
+    - name: ibmcloud_api_key
+    - name: name_prefix

--- a/src/models/bill-of-material.model.spec.ts
+++ b/src/models/bill-of-material.model.spec.ts
@@ -1,0 +1,54 @@
+import {BillOfMaterial} from './bill-of-material.model';
+
+describe('bill-of-material model', () => {
+  test('canary verifies test infrastructure', () => {
+    expect(true).toBe(true);
+  });
+
+  describe('given getModules()', () => {
+    describe('when models are defined with id string', () => {
+      const modules = ['module1', 'module2'];
+
+      let classUnderTest: BillOfMaterial;
+      beforeEach(() => {
+        classUnderTest = new BillOfMaterial({spec: {modules}})
+      });
+
+      test('then should resolve modules with id', async () => {
+        const actual = BillOfMaterial.getModules(classUnderTest);
+
+        expect(actual).toEqual(modules.map(id => ({id})));
+      });
+    });
+
+    describe('when models are defined as object with name string', () => {
+      const modules = [{name: 'module1'}, {name: 'module2'}];
+
+      let classUnderTest: BillOfMaterial;
+      beforeEach(() => {
+        classUnderTest = new BillOfMaterial({spec: {modules}})
+      });
+
+      test('then should resolve modules with id', async () => {
+        const actual = BillOfMaterial.getModules(classUnderTest);
+
+        expect(actual).toEqual(modules);
+      });
+    });
+
+    describe('when models are defined as object with id string', () => {
+      const modules = [{id: 'module1'}, {id: 'module2'}];
+
+      let classUnderTest: BillOfMaterial;
+      beforeEach(() => {
+        classUnderTest = new BillOfMaterial({spec: {modules}})
+      });
+
+      test('then should resolve modules with id', async () => {
+        const actual = BillOfMaterial.getModules(classUnderTest);
+
+        expect(actual).toEqual(modules);
+      });
+    });
+  });
+});

--- a/src/models/bill-of-material.model.ts
+++ b/src/models/bill-of-material.model.ts
@@ -1,13 +1,45 @@
 import {isSingleModuleVersion, Module, SingleModuleVersion} from './module.model';
 import {of} from '../util/optional';
 
-export interface BillOfMaterialModule {
-  id: string;
-  version?: string;
+export interface BillOfMaterialModuleDependency {
+  name: string;
+  ref: string;
 }
 
+export interface BillOfMaterialModuleVariable {
+  name: string;
+  value: any;
+}
+
+export interface BaseBillOfMaterialModule {
+  alias?: string;
+  version?: string;
+  variables?: BillOfMaterialModuleVariable[];
+  dependencies?: BillOfMaterialModuleDependency[];
+}
+
+export interface BillOfMaterialModuleById extends BaseBillOfMaterialModule {
+  id: string;
+  name?: string;
+}
+
+export interface BillOfMaterialModuleByName extends BaseBillOfMaterialModule {
+  name: string;
+  id?: string;
+}
+
+export type BillOfMaterialModule = BillOfMaterialModuleById | BillOfMaterialModuleByName;
+
 export function isBillOfMaterialModule(module: string | BillOfMaterialModule): module is BillOfMaterialModule {
+  return !!module && (!!(module as BillOfMaterialModule).id || !!(module as BillOfMaterialModule).name);
+}
+
+export function isBillOfMaterialModuleById(module: string | BillOfMaterialModule): module is BillOfMaterialModuleById {
   return !!module && !!(module as BillOfMaterialModule).id;
+}
+
+export function isBillOfMaterialModuleByName(module: string | BillOfMaterialModule): module is BillOfMaterialModuleByName {
+  return !!module && !!(module as BillOfMaterialModule).name;
 }
 
 export interface BillOfMaterialVariable {
@@ -54,13 +86,13 @@ export class BillOfMaterial implements BillOfMaterialModel {
     variables: [],
   };
 
-  static getModuleIds(model?: BillOfMaterialModel): string[] {
+  static getModuleRefs(model?: BillOfMaterialModel): BillOfMaterialModule[] {
     const modules: Array<string | BillOfMaterialModule> = of<BillOfMaterialModel>(model)
       .map(m => m.spec)
       .map(s => s.modules)
       .orElse([]);
 
-    return modules.map((module: string | BillOfMaterialModule) => isBillOfMaterialModule(module) ? module.id : module)
+    return modules.map((module: string | BillOfMaterialModule) => isBillOfMaterialModuleById(module) ? {id: module.id} : isBillOfMaterialModuleByName(module) ? {name: module.name} : {id: module})
   }
 
   static getModules(model?: BillOfMaterialModel): BillOfMaterialModule[] {

--- a/src/models/catalog.model.spec.ts
+++ b/src/models/catalog.model.spec.ts
@@ -1,0 +1,41 @@
+import {Catalog} from './catalog.model';
+import {Container} from 'typescript-ioc';
+import {LoggerApi} from '../util/logger';
+import {NoopLoggerImpl} from '../util/logger/noop-logger.impl';
+import {CatalogLoaderApi} from '../services';
+
+describe('catalog model', () => {
+  test('canary verifies test infrastructure', () => {
+    expect(true).toBe(true);
+  });
+
+  let classUnderTest: Catalog;
+  beforeAll(async () => {
+    Container.bind(LoggerApi).to(NoopLoggerImpl);
+
+    const catalogLoader: CatalogLoaderApi = Container.get(CatalogLoaderApi);
+    classUnderTest = await catalogLoader.loadCatalog(`file:/${process.cwd()}/test/catalog.yaml`)
+  });
+
+  describe('given lookupModule()', () => {
+    describe('when called with a valid id', () => {
+      test('then it should return a module', async () => {
+        const id = 'github.com/cloud-native-toolkit/terraform-ibm-container-platform';
+
+        const actualResult = classUnderTest.lookupModule({id});
+        expect(actualResult).toBeDefined();
+        expect(actualResult?.id).toBe(id);
+      });
+    });
+
+    describe('when called with a valid name', () => {
+      test('then it should return a module', async () => {
+        const name = 'ibm-container-platform';
+
+        const actualResult = classUnderTest.lookupModule({name});
+        expect(actualResult).toBeDefined();
+        expect(actualResult?.name).toBe(name);
+      });
+    });
+  });
+});

--- a/src/models/module.model.ts
+++ b/src/models/module.model.ts
@@ -1,4 +1,5 @@
 import {VersionMatcher} from './version-matcher';
+import {BillOfMaterialModule} from './bill-of-material.model';
 
 export interface ModuleRef {
   source: string;
@@ -27,6 +28,7 @@ export interface ModuleTemplate {
 
 export interface Module extends ModuleTemplate {
   versions: ModuleVersion[];
+  bomModule?: BillOfMaterialModule;
 }
 
 export function isModule(module: Module | ModuleRef): module is Module {
@@ -39,6 +41,7 @@ export function isModuleRef(module: Module | ModuleRef): module is ModuleRef {
 
 export interface SingleModuleVersion extends ModuleTemplate {
   version: ModuleVersion;
+  bomModule?: BillOfMaterialModule;
 }
 
 export function isSingleModuleVersion(module: Module | SingleModuleVersion): module is SingleModuleVersion {
@@ -49,6 +52,7 @@ export interface ModuleDependency {
   id: string;
   refs: ModuleRef[];
   optional?: boolean;
+  discriminator?: string;
 }
 
 export interface ModuleVersion {

--- a/src/models/stages.model.ts
+++ b/src/models/stages.model.ts
@@ -75,7 +75,7 @@ export class TerraformVariablesFile implements OutputFile {
 }
 
 export class TerraformComponent implements TerraformComponentModel {
-  stages: { [source: string]: Stage } = {};
+  stages: { [name: string]: Stage } = {};
   baseVariables: TerraformVariable[] = [];
   modules?: SingleModuleVersion[];
 

--- a/src/models/variables.model.ts
+++ b/src/models/variables.model.ts
@@ -18,7 +18,7 @@ export interface BaseVariable extends IBaseVariable, StagePrinter {
 }
 
 export interface IModuleVariable extends IBaseVariable {
-  moduleRef: {source: string};
+  moduleRef: {stageName: string};
   moduleOutputName: string;
 }
 
@@ -28,7 +28,7 @@ export class ModuleRefVariable implements IModuleVariable, BaseVariable {
   type?: string;
   scope?: 'global' | 'module' | 'ignore' = 'module';
 
-  moduleRef: {source: string};
+  moduleRef: {stageName: string};
   moduleOutputName: string;
 
   constructor(values: IModuleVariable) {
@@ -41,7 +41,7 @@ export class ModuleRefVariable implements IModuleVariable, BaseVariable {
   }
 
   asString(stages: {[name: string]: {name: string}}): string {
-    const module: {name: string} = stages[this.moduleRef.source];
+    const module: {name: string} = stages[this.moduleRef.stageName];
 
     return `${this.name} = module.${module.name}.${this.moduleOutputName}\n`;
   }

--- a/src/services/iascable.impl.ts
+++ b/src/services/iascable.impl.ts
@@ -38,7 +38,7 @@ export class CatalogBuilder implements IascableApi {
 
     const modules: SingleModuleVersion[] = await this.moduleSelector.resolveBillOfMaterial(catalog, billOfMaterial);
 
-    const terraformComponent: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules);
+    const terraformComponent: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules, billOfMaterial);
 
     const tile: Tile | undefined = options?.tileConfig ? await this.tileBuilder.buildTileMetadata(terraformComponent.baseVariables, options.tileConfig) : undefined;
 

--- a/src/services/module-selector/module-selector.impl.spec.ts
+++ b/src/services/module-selector/module-selector.impl.spec.ts
@@ -1,0 +1,205 @@
+import {ModuleSelectorApi} from './module-selector.api';
+import {Container} from 'typescript-ioc';
+import {
+  BillOfMaterial,
+  BillOfMaterialModel,
+  BillOfMaterialModule, BillOfMaterialModuleDependency,
+  CatalogModel, ModuleDependency,
+  SingleModuleVersion
+} from '../../models';
+import {CatalogLoaderApi} from '../catalog-loader';
+import {ModuleSelector} from './module-selector.impl';
+import {LoggerApi} from '../../util/logger';
+import {NoopLoggerImpl} from '../../util/logger/noop-logger.impl';
+import {isDefinedAndNotNull} from '../../util/object-util';
+
+describe('module-selector', () => {
+  test('canary verifies test infrastructure', () => {
+    expect(true).toBe(true);
+  });
+
+  let catalog: CatalogModel;
+
+  let classUnderTest: ModuleSelectorApi;
+  beforeEach(async () => {
+    Container.bind(LoggerApi).to(NoopLoggerImpl);
+
+    const catalogLoader: CatalogLoaderApi = Container.get(CatalogLoaderApi);
+    catalog = await catalogLoader.loadCatalog(`file:/${process.cwd()}/test/catalog.yaml`)
+
+    classUnderTest = Container.get(ModuleSelector);
+  });
+
+  describe('given resolveBillOfMaterial()', () => {
+    describe('when BOM defines IDs of valid modules', () => {
+      const modules = [
+        'github.com/cloud-native-toolkit/terraform-ibm-container-platform',
+        'github.com/cloud-native-toolkit/terraform-tools-argocd',
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then should resolve modules', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        const actualIds = actualResult.map(m => m.id).filter(id => modules.includes(id));
+        expect(actualIds).toEqual(modules);
+
+        expect(actualResult.map(m => m.bomModule).filter(m => !!m).length).toEqual(modules.length);
+        expect(actualResult.map(m => m.bomModule).filter(m => !m).length).toEqual(actualResult.length - modules.length);
+      });
+    });
+    describe('when BOM defines names of valid modules', () => {
+      const modules = [
+        {name: 'ibm-container-platform'},
+        {name: 'argocd'},
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then should resolve modules', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        expect(actualResult.length).toBeGreaterThan(0);
+        const mapNames = actualResult.map(m => ({name: m.name})).filter(m => modules.some(v => v.name === m.name));
+        expect(mapNames).toEqual(modules);
+      });
+    });
+    describe('when BOM defines the same module multiple times', () => {
+      const modules = [
+        {name: 'ibm-container-platform'},
+        {name: 'namespace'},
+        {name: 'namespace'},
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then should resolve modules', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        expect(actualResult.length).toEqual(modules.length);
+        const mapNames = actualResult.map(m => ({name: m.name})).filter(m => modules.some(v => v.name === m.name));
+        expect(mapNames).toEqual(modules);
+        const aliases = actualResult.map(m => m.alias);
+        expect(aliases).toEqual(['cluster', 'namespace', 'namespace1']);
+      });
+    });
+    describe('when BOM defines modules with aliases', () => {
+      const modules = [
+        {name: 'ibm-container-platform', alias: 'cluster'},
+        {name: 'namespace', alias: 'tools-namespace'},
+        {name: 'namespace', alias: 'observability-namespace'},
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then should resolve modules with alias names from BOM', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        expect(actualResult.length).toEqual(modules.length);
+        const mapNames = actualResult.map(m => ({name: m.name})).filter(m => modules.some(v => v.name === m.name));
+        expect(mapNames).toEqual(modules.map(m => ({name: m.name})));
+        const aliases = actualResult.map(m => m.alias);
+        expect(aliases).toEqual(modules.map(m => m.alias));
+
+        expect(actualResult.map(m => m.bomModule).filter(m => !!m).length).toEqual(modules.length);
+        expect(actualResult.map(m => m.bomModule).filter(m => !m).length).toEqual(actualResult.length - modules.length);
+      });
+    });
+    describe('when BOM module has a dependency that refers to a particular module alias that does not already exist', () => {
+      const modules: BillOfMaterialModule[] = [
+        {name: 'ibm-container-platform'},
+        {name: 'namespace', alias: 'tools-namespace', dependencies: [{name: 'cluster', ref: 'mycluster'}]},
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then it should add a new module with that name', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        expect(actualResult.length).toEqual(3);
+        expect(actualResult.map(m => m.alias)).toEqual(['cluster', 'tools-namespace', 'mycluster']);
+
+        const dependencies: Array<Array<BillOfMaterialModuleDependency> | undefined> = actualResult.map(m => m.bomModule?.dependencies).filter(isDefinedAndNotNull);
+        const discriminators: string[] = dependencies.reduce((result: string[], d: Array<BillOfMaterialModuleDependency> | undefined) => {
+
+          if (!d) {
+            return result;
+          }
+
+          result.push(...d.map(dep => dep.ref as any).filter(isDefinedAndNotNull));
+
+          return result;
+        }, [] as string[])
+        console.log('Discriminators: ', discriminators);
+        expect(dependencies.every(d => d?.every(x => !!x.ref))).toBe(true);
+      });
+    });
+    describe('when BOM module has a dependency that refers to a particular module alias that already exists', () => {
+      const modules: BillOfMaterialModule[] = [
+        {name: 'ibm-container-platform'},
+        {name: 'namespace', alias: 'tools-namespace', dependencies: [{name: 'cluster', ref: 'mycluster'}]},
+        {name: 'namespace', alias: 'namespace', dependencies: [{name: 'cluster', ref: 'cluster'}]},
+      ];
+
+      let bom: BillOfMaterialModel;
+      beforeEach(() => {
+        bom = new BillOfMaterial({spec: {modules}});
+      });
+
+      test('then it should add a new module with that name', async () => {
+        const actualResult: SingleModuleVersion[] = await classUnderTest.resolveBillOfMaterial(
+          catalog,
+          bom,
+        );
+
+        expect(actualResult.length).toEqual(4);
+        expect(actualResult.map(m => m.alias)).toEqual(['cluster', 'tools-namespace', 'mycluster', 'namespace']);
+
+        const dependencies: Array<Array<BillOfMaterialModuleDependency> | undefined> = actualResult.map(m => m.bomModule?.dependencies).filter(isDefinedAndNotNull);
+        const discriminators: string[] = dependencies.reduce((result: string[], d: Array<BillOfMaterialModuleDependency> | undefined) => {
+
+          if (!d) {
+            return result;
+          }
+
+          result.push(...d.map(dep => dep.ref as any).filter(isDefinedAndNotNull));
+
+          return result;
+        }, [] as string[])
+        console.log('Discriminators: ', discriminators);
+        expect(dependencies.every(d => d?.every(x => !!x.ref))).toBe(true);
+      });
+    });
+  });
+});

--- a/src/services/terraform-builder/terraform-buiilder.impl.spec.ts
+++ b/src/services/terraform-builder/terraform-buiilder.impl.spec.ts
@@ -1,0 +1,92 @@
+import {
+  BillOfMaterial,
+  BillOfMaterialModel,
+  BillOfMaterialModule, CatalogModel, GlobalRefVariable, isModuleRefVariable, ModuleRefVariable,
+  SingleModuleVersion
+} from '../../models';
+import {TerraformBuilder} from './terraform-builder.impl';
+import {Container} from 'typescript-ioc';
+import {LoggerApi} from '../../util/logger';
+import {NoopLoggerImpl} from '../../util/logger/noop-logger.impl';
+import {ModuleSelectorApi} from '../module-selector';
+import {CatalogLoaderApi} from '../catalog-loader';
+
+describe('terraform-builder', () => {
+  test('canary verifies test infrastructure', () => {
+    expect(true).toBe(true);
+  });
+
+  let classUnderTest: TerraformBuilder;
+
+  let catalog: CatalogModel;
+  let moduleSelector: ModuleSelectorApi;
+  beforeEach(async () => {
+    Container.bind(LoggerApi).to(NoopLoggerImpl);
+
+    const catalogLoader: CatalogLoaderApi = Container.get(CatalogLoaderApi);
+    catalog = await catalogLoader.loadCatalog(`file:/${process.cwd()}/test/catalog.yaml`)
+
+    moduleSelector = Container.get(ModuleSelectorApi);
+
+    classUnderTest = Container.get(TerraformBuilder);
+  })
+
+  describe('given buildTerraformComponent()', () => {
+    describe('when BOM module references a dependent module alias', () => {
+      const modules: BillOfMaterialModule[] = [
+        {name: 'ibm-container-platform'},
+        {name: 'namespace', alias: 'tools-namespace', dependencies: [{name: 'cluster', ref: 'mycluster'}]},
+        {name: 'namespace', alias: 'namespace', dependencies: [{name: 'cluster', ref: 'cluster'}]},
+      ];
+
+      let bom: BillOfMaterialModel;
+      let selectedModules: SingleModuleVersion[];
+      beforeEach(async () => {
+        bom = new BillOfMaterial({spec: {modules}});
+
+        selectedModules = await moduleSelector.resolveBillOfMaterial(catalog, bom);
+      });
+
+      test('then use the module defined by the alias', async () => {
+        const result = await classUnderTest.buildTerraformComponent(selectedModules, bom);
+
+        expect(Object.keys(result.stages).length).toEqual(4);
+
+        const variableRefs = result.stages['tools-namespace'].variables
+          .filter(v => isModuleRefVariable(v))
+          .map(v => (v as ModuleRefVariable).moduleRef.stageName)
+
+        expect(variableRefs.reduce((result: string[], val: string) => {
+          if (!result.includes(val)) {
+            result.push(val);
+          }
+
+          return result;
+        }, [])).toEqual(['mycluster']);
+      });
+    });
+
+    describe('when BOM module references variables', () => {
+      const modules: BillOfMaterialModule[] = [
+        {name: 'ibm-container-platform'},
+        {name: 'namespace', alias: 'tools-namespace', variables: [{name: 'name', value: 'tools'}]},
+      ];
+
+      let bom: BillOfMaterialModel;
+      let selectedModules: SingleModuleVersion[];
+      beforeEach(async () => {
+        bom = new BillOfMaterial({spec: {modules}});
+
+        selectedModules = await moduleSelector.resolveBillOfMaterial(catalog, bom);
+      });
+
+      test('then apply the variables to the resulting terraform module', async () => {
+        const result = await classUnderTest.buildTerraformComponent(selectedModules, bom);
+
+        const variableName = result.stages['tools-namespace'].variables.filter(v => v.name === 'name').map(v => (v as GlobalRefVariable).variableName)[0];
+        const variables = result.baseVariables.filter(v => v.name === variableName).map(v => v.defaultValue);
+        expect(variables).toEqual(['tools']);
+      });
+    });
+  });
+});

--- a/src/services/terraform-builder/terraform-builder.api.ts
+++ b/src/services/terraform-builder/terraform-builder.api.ts
@@ -1,8 +1,8 @@
 import {SingleModuleVersion} from '../../models/module.model';
 import {TerraformComponent, TerraformComponentModel} from '../../models/stages.model';
-import {BillOfMaterialModel} from '../../models/bill-of-material.model';
+import {BillOfMaterial, BillOfMaterialModel} from '../../models/bill-of-material.model';
 import {CatalogModel} from '../../models/catalog.model';
 
 export abstract class TerraformBuilderApi {
-  abstract buildTerraformComponent(modules: SingleModuleVersion[]): Promise<TerraformComponent>;
+  abstract buildTerraformComponent(modules: SingleModuleVersion[], billOfMaterial: BillOfMaterialModel): Promise<TerraformComponent>;
 }

--- a/src/util/array-util.ts
+++ b/src/util/array-util.ts
@@ -15,12 +15,18 @@ export class ArrayUtil<T = any> {
     return new ArrayUtil(array);
   }
 
-  filter(f: (value: T) => boolean): ArrayUtil<T> {
+  filter(f: (value: T, index: number, array: T[]) => boolean): ArrayUtil<T> {
     return new ArrayUtil(this.value.filter(f));
   }
 
-  map<U>(f: (value: T) => U): ArrayUtil<U> {
+  map<U>(f: (value: T, index: number, array: T[]) => U): ArrayUtil<U> {
     return new ArrayUtil(this.value.map(f));
+  }
+
+  forEach(f: (value: T, index: number, array: T[]) => void): ArrayUtil<T> {
+    this.value.forEach(f);
+
+    return this;
   }
 
   first(): Optional<T> {

--- a/src/util/logger/logger.api.ts
+++ b/src/util/logger/logger.api.ts
@@ -1,8 +1,8 @@
 
 export abstract class LoggerApi {
-  abstract info(message: string, context?: any): void;
-  abstract debug(message: string, context?: any): void;
-  abstract error(message: string, context?: any): void;
-  abstract warn(message: string, context?: any): void;
+  abstract info(message: string, ...context: any[]): void;
+  abstract debug(message: string, ...context: any[]): void;
+  abstract error(message: string, ...context: any[]): void;
+  abstract warn(message: string, ...context: any[]): void;
   abstract child(name: string): LoggerApi;
 }

--- a/src/util/logger/noop-logger.impl.ts
+++ b/src/util/logger/noop-logger.impl.ts
@@ -1,0 +1,19 @@
+import {LoggerApi} from './logger.api';
+
+export class NoopLoggerImpl implements LoggerApi {
+  child(name: string): LoggerApi {
+    return this;
+  }
+
+  debug(message: string, context?: any): void {
+  }
+
+  error(message: string, context?: any): void {
+  }
+
+  info(message: string, context?: any): void {
+  }
+
+  warn(message: string, context?: any): void {
+  }
+}

--- a/src/util/version-resolver/version-resolver.ts
+++ b/src/util/version-resolver/version-resolver.ts
@@ -115,16 +115,28 @@ export const resolveVersions = (versions: Array<string | VersionMatcher[]>): Ver
 
 export function findMatchingVersion<T extends {version: string}, M extends {id: string, versions: Array<T>}>(
   module: M,
-  matchers: VersionMatcher[],
+  matchers: string | VersionMatcher[],
 ): T {
 
-  const matchingVersions: Array<T> = module.versions
-    .sort((a: T, b: T) => compareVersions(a.version, b.version) * -1)
-    .filter(m => matchers.every(v => compareVersions.compare(m.version, v.version, asCompareOperator(v.comparator))));
+  const matchingVersions: Array<T> = findMatchingVersions(module, matchers);
 
   if (matchingVersions.length === 0) {
     throw new ModuleVersionNotFound(module, matchers);
   }
 
   return matchingVersions[0];
+}
+
+export function findMatchingVersions<T extends {version: string}, M extends {id: string, versions: Array<T>}>(
+  module: M,
+  versionMatchers: string | VersionMatcher[],
+): Array<T> {
+
+  const matchers: VersionMatcher[] = parseVersionMatcher(versionMatchers);
+
+  const matchingVersions: Array<T> = module.versions
+    .sort((a: T, b: T) => compareVersions(a.version, b.version) * -1)
+    .filter(m => matchers.every(v => compareVersions.compare(m.version, v.version, asCompareOperator(v.comparator))));
+
+  return matchingVersions;
 }

--- a/test/catalog.yaml
+++ b/test/catalog.yaml
@@ -1,0 +1,13262 @@
+categories:
+  - category: cluster
+    categoryName: Cluster
+    selection: single
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+        name: ibm-container-platform
+        description: Provisions a new or connects to an existing IBM Cloud container platform cluster (Kubernetes or OpenShift)
+        alias: cluster
+        tags:
+          - cluster
+          - ibm cloud
+          - kubernetes
+          - openshift
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: module
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                default: ""
+                optional: true
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+            version: v1.20.8
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: module
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                default: ""
+                optional: true
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+            version: v1.20.7
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                default: ""
+                optional: true
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: module
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                default: ""
+                optional: true
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+            version: v1.20.6
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: module
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+            version: v1.20.5
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: opc_entitlement
+                scope: module
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+            version: v1.20.4
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - nane: cluster_type
+                scope: global
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: opc_entitlement
+                scope: module
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+            version: v1.20.3
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                default: shared
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                default: b3c.4x16
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                default: 0
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - nane: cluster_type
+                scope: global
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: apikey
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                default: false
+                optional: true
+              - name: opc_entitlement
+                scope: module
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                default: true
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+            version: v1.20.2
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                scope: global
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                scope: global
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                optional: true
+              - name: cluster_worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                optional: true
+              - name: cluster_machine_type
+                scope: global
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: flavor
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: vlan_datacenter
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                optional: true
+              - name: private_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: public_vlan_id
+                scope: module
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: vpc_zone_count
+                scope: module
+                type: number
+                description: Number of vpc zones
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - nane: cluster_type
+                scope: global
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                scope: global
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: is_vpc
+                scope: module
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                optional: true
+              - name: opc_entitlement
+                scope: module
+              - name: cos_name
+                scope: module
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                optional: true
+              - name: provision_cos
+                scope: module
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                optional: true
+            version: v1.20.1
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - version: v1.20.0
+            variables:
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                optional: true
+              - name: cluster_worker_count
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                optional: true
+              - name: cluster_machine_type
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: flavor
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: vlan_datacenter
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                optional: true
+              - name: private_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: public_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: vpc_zone_count
+                type: number
+                description: Number of vpc zones
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: is_vpc
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                optional: true
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                optional: true
+              - name: cos_name
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                optional: true
+              - name: provision_cos
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - version: v1.19.1
+            variables:
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                optional: true
+              - name: cluster_worker_count
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                optional: true
+              - name: cluster_machine_type
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: flavor
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: vlan_datacenter
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                optional: true
+              - name: private_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: public_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: vpc_zone_names
+                type: list(string)
+                description: List of vpc zones
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: is_vpc
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                optional: true
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                optional: true
+              - name: cos_name
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                optional: true
+              - name: provision_cos
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+          - version: v1.19.0
+            variables:
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: cluster_name
+                type: string
+                description: The name of the cluster that will be created within the resource group
+              - name: cluster_hardware
+                type: string
+                description: The type of hardware for the cluster (shared, dedicated)
+                optional: true
+              - name: cluster_worker_count
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                optional: true
+              - name: cluster_machine_type
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: flavor
+                type: string
+                description: (Deprecated, use VPC) The machine type that will be provisioned for classic infrastructure
+                optional: true
+              - name: vlan_datacenter
+                type: string
+                description: (Deprecated, use VPC) The datacenter that should be used for classic infrastructure provisioning
+                optional: true
+              - name: private_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The private vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: public_vlan_id
+                type: string
+                description: (Deprecated, use VPC) The public vlan id that should be used for classic infrastructure provisioning
+                optional: true
+              - name: vpc_zone_names
+                type: list(string)
+                description: List of vpc zones
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: cluster_type
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: cluster_exists
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+              - name: login_user
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: is_vpc
+                type: bool
+                description: Flag indicating that the cluster uses vpc infrastructure
+                optional: true
+              - name: ocp_entitlement
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                optional: true
+              - name: cos_name
+                type: string
+                description: (optional) The name of the cos instance that will be used for the OCP 4 vpc instance
+                optional: true
+              - name: provision_cos
+                type: bool
+                description: Flag indicating that the cos instance should be provisioned, if necessary
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: (Deprecated) Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: (Deprecated) Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: (Deprecated) The username used to log into the openshift cli
+              - name: login_password
+                description: (Deprecated) The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: (Deprecated) The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag based on the cluster type
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+        name: ocp-cluster
+        description: Connects to an existing OpenShift cluster
+        alias: cluster
+        tags:
+          - cluster
+          - openshift
+        versions:
+          - platforms:
+              - ocp4
+            dependencies: []
+            variables:
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster into which the toolkit will be installed (openshift or ocp3 or ocp4)
+                default: ocp4
+                optional: true
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+              - name: login_password
+                scope: module
+                type: string
+                description: The password to log in to openshift
+              - name: login_token
+                scope: module
+                type: string
+                description: The token to log in to openshift
+              - name: server_url
+                scope: module
+                type: string
+                description: The url to the server
+              - name: resource_group_name
+                scope: ignore
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+                default: N/A
+                optional: true
+              - name: cluster_region
+                scope: ignore
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+                default: N/A
+                optional: true
+              - name: ingress_subdomain
+                scope: ignore
+                type: string
+                description: The ROUTER_CANONICAL_HOSTNAME for the cluster
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+            version: v2.4.4
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: The username used to log into the openshift cli
+              - name: login_password
+                description: The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag vased on the cluster type
+          - platforms:
+              - ocp4
+            dependencies: []
+            variables:
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster into which the toolkit will be installed (openshift or ocp3 or ocp4)
+                default: ocp4
+                optional: true
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+              - name: login_password
+                scope: module
+                type: string
+                description: The password to log in to openshift
+              - name: login_token
+                scope: module
+                type: string
+                description: The token to log in to openshift
+              - name: server_url
+                scope: module
+                type: string
+                description: The url to the server
+              - name: resource_group_name
+                scope: ignore
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+                default: N/A
+                optional: true
+              - name: cluster_region
+                scope: ignore
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+                default: N/A
+                optional: true
+              - name: ingress_subdomain
+                scope: ignore
+                type: string
+                description: The ROUTER_CANONICAL_HOSTNAME for the cluster
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+            version: v2.4.3
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: The username used to log into the openshift cli
+              - name: login_password
+                description: The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag vased on the cluster type
+          - platforms:
+              - ocp4
+            dependencies: []
+            variables:
+              - name: cluster_type
+                scope: global
+                type: string
+                description: The type of cluster into which the toolkit will be installed (openshift or ocp3 or ocp4)
+                default: '"ocp4"'
+                optional: true
+              - name: login_user
+                scope: module
+                type: string
+                description: The username to log in to openshift
+                default: '""'
+                optional: true
+              - name: login_password
+                scope: module
+                type: string
+                description: The password to log in to openshift
+                default: '""'
+                optional: true
+              - name: login_token
+                scope: module
+                type: string
+                description: The token to log in to openshift
+                default: '""'
+                optional: true
+              - name: server_url
+                scope: module
+                type: string
+                description: The url to the server
+              - name: resource_group_name
+                scope: ignore
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+                default: '"N/A"'
+                optional: true
+              - name: cluster_region
+                scope: ignore
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+                default: '"N/A"'
+                optional: true
+              - name: ingress_subdomain
+                scope: ignore
+                type: string
+                description: The ROUTER_CANONICAL_HOSTNAME for the cluster
+                default: '""'
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: '""'
+                optional: true
+            version: v2.4.2
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: The username used to log into the openshift cli
+              - name: login_password
+                description: The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag vased on the cluster type
+          - version: v2.4.1
+            variables:
+              - name: cluster_type
+                type: string
+                description: The type of cluster into which the toolkit will be installed (openshift or ocp3 or ocp4)
+                optional: true
+              - name: login_user
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: login_password
+                type: string
+                description: The password to log in to openshift
+                optional: true
+              - name: login_token
+                type: string
+                description: The token to log in to openshift
+                optional: true
+              - name: server_url
+                type: string
+                description: The url to the server
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+                optional: true
+              - name: ingress_subdomain
+                type: string
+                description: The ROUTER_CANONICAL_HOSTNAME for the cluster
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: The username used to log into the openshift cli
+              - name: login_password
+                description: The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag vased on the cluster type
+          - version: v2.4.0
+            variables:
+              - name: cluster_type
+                type: string
+                description: The type of cluster into which the toolkit will be installed (openshift or ocp3 or ocp4)
+                optional: true
+              - name: login_user
+                type: string
+                description: The username to log in to openshift
+                optional: true
+              - name: login_password
+                type: string
+                description: The password to log in to openshift
+                optional: true
+              - name: login_token
+                type: string
+                description: The token to log in to openshift
+                optional: true
+              - name: server_url
+                type: string
+                description: The url to the server
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+                optional: true
+              - name: ingress_subdomain
+                type: string
+                description: The ROUTER_CANONICAL_HOSTNAME for the cluster
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: ingress_hostname
+                description: Ingress hostname of the cluster.
+              - name: server_url
+                description: The url of the control server.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: type
+                description: (Deprecated, use platform.type) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: type_code
+                description: (Deprecated, use platform.type_code) The type of cluster (openshift or ocp4 or ocp3 or kubernetes)
+              - name: platform
+                description: Configuration values for the cluster platform
+              - name: version
+                description: (Deprecated, use platform.version) The point release version number of cluster (3.11 or 4.3 or 1.16)
+              - name: login_user
+                description: The username used to log into the openshift cli
+              - name: login_password
+                description: The password used to log into the openshift cli
+              - name: tls_secret_name
+                description: The name of the secret containin the tls information for the cluster
+              - name: tag
+                description: The tag vased on the cluster type
+        aliasIds:
+          - github.com/cloud-native-toolkit/terraform-ocp-cluster
+        provider: k8s
+      - id: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+        name: ibm-ocp-vpc
+        alias: cluster
+        type: terraform
+        description: Provisions an IBM Cloud OCP cluster
+        tags:
+          - ocp
+          - cluster
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cos
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-object-storage
+                    version: ">= 2.1.0"
+              - id: vpc
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+                    version: ">= 1.0.0"
+            variables:
+              - name: vpc_name
+                moduleRef:
+                  id: vpc
+                  output: name
+                type: string
+                description: Name of the VPC instance that will be used
+              - name: vpc_subnet_count
+                moduleRef:
+                  id: vpc
+                  output: subnet_count
+                type: number
+                description: Number of vpc zones
+              - name: cos_id
+                moduleRef:
+                  id: cos
+                  output: id
+                type: string
+                description: The crn of the COS instance that will be used with the OCP instance
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: name
+                scope: module
+                type: string
+                description: The name of the cluster that will be created within the resource group
+                default: ""
+                optional: true
+              - name: worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: ocp_version
+                scope: global
+                type: string
+                description: The version of the OpenShift cluster that should be provisioned (format 4.x)
+                default: "4.6"
+                optional: true
+              - name: exists
+                scope: module
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: ignore
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: flavor
+                type: string
+                description: The machine type that will be provisioned for classic infrastructure
+                default: bx2.4x16
+                optional: true
+              - name: disable_public_endpoint
+                type: bool
+                description: Flag indicating that the public endpoint should be disabled
+                default: false
+                optional: true
+            version: v1.1.1
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: platform
+                description: Configuration values for the cluster platform
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cos
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-object-storage
+                    version: ">= 2.1.0"
+              - id: vpc
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+                    version: ">= 1.0.0"
+            variables:
+              - name: vpc_name
+                moduleRef:
+                  id: vpc
+                  output: name
+                type: string
+                description: Name of the VPC instance that will be used
+              - name: vpc_subnet_count
+                moduleRef:
+                  id: vpc
+                  output: subnet_count
+                type: number
+                description: Number of vpc zones
+              - name: cos_id
+                moduleRef:
+                  id: cos
+                  output: id
+                type: string
+                description: The crn of the COS instance that will be used with the OCP instance
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: name
+                scope: module
+                type: string
+                description: The name of the cluster that will be created within the resource group
+                default: ""
+                optional: true
+              - name: worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: ocp_version
+                scope: global
+                type: string
+                description: The version of the OpenShift cluster that should be provisioned (format 4.x)
+                default: 4.6 validation { condition = ( regex(^4[.], var.ocp_version) == 4. ) error_message = The ocp_version must be formatted as 4.x.
+                optional: true
+              - name: exists
+                scope: module
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: ignore
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: cos_name
+                scope: global
+              - name: provision_cos
+                scope: global
+              - name: flavor
+                type: string
+                description: The machine type that will be provisioned for classic infrastructure
+                default: bx2.4x16
+                optional: true
+              - name: disable_public_endpoint
+                type: bool
+                description: Flag indicating that the public endpoint should be disabled
+                default: false
+                optional: true
+            version: v1.1.0
+            outputs:
+              - name: id
+                description: ID of the cluster.
+              - name: name
+                description: Name of the cluster.
+              - name: resource_group_name
+                description: Name of the resource group containing the cluster.
+              - name: region
+                description: Region containing the cluster.
+              - name: config_file_path
+                description: Path to the config file for the cluster.
+              - name: platform
+                description: Configuration values for the cluster platform
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cos
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-object-storage
+                    version: ">= 2.1.0"
+              - id: vpc
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+                    version: ">= 1.0.0"
+            variables:
+              - name: vpc_name
+                moduleRef:
+                  id: vpc
+                  output: name
+                type: string
+                description: Name of the VPC instance that will be used
+              - name: vpc_subnet_count
+                moduleRef:
+                  id: vpc
+                  output: subnet_count
+                type: number
+                description: Number of vpc zones
+              - name: cos_id
+                moduleRef:
+                  id: cos
+                  output: id
+                type: string
+                description: The crn of the COS instance that will be used with the OCP instance
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: name
+                scope: module
+                type: string
+                description: The name of the cluster that will be created within the resource group
+                default: ""
+                optional: true
+              - name: worker_count
+                scope: global
+                type: number
+                description: The number of worker nodes that should be provisioned for classic infrastructure
+                default: 3
+                optional: true
+              - name: ocp_version
+                scope: global
+                type: string
+                description: The version of the OpenShift cluster that should be provisioned (format 4.x)
+                default: 4.6 validation { condition = ( regex(^4[.], var.ocp_version) == 4. ) error_message = The ocp_version must be formatted as 4.x.
+                optional: true
+              - name: exists
+                scope: module
+                type: bool
+                description: Flag indicating if the cluster already exists (true or false)
+                default: false
+                optional: true
+              - name: ocp_entitlement
+                scope: ignore
+                type: string
+                description: Value that is applied to the entitlements for OCP cluster provisioning
+                default: cloud_pak
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: cos_name
+                scope: global
+              - name: provision_cos
+                scope: global
+              - name: flavor
+                type: string
+                description: The machine type that will be provisioned for classic infrastructure
+                default: bx2.4x16
+                optional: true
+              - name: disable_public_endpoint
+                type: bool
+                description: Flag indicating that the public endpoint should be disabled
+                default: false
+                optional: true
+            version: v1.0.0
+        provider: ibm
+  - category: dev-tool
+    categoryName: Dev Tools
+    selection: multiple
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-tools-argocd
+        name: argocd
+        type: terraform
+        description: Module to install ArgoCD into a cluster via an operator
+        tags:
+          - tools
+          - devops
+          - gitops
+          - argocd
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: olm
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-olm
+                    version: ">= 1.2.2"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The type of cluster (openshift or kubernetes)
+              - name: ingress_subdomain
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: The subdomain for ingresses in the cluster
+                default: ""
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: olm_namespace
+                moduleRef:
+                  id: olm
+                  output: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+              - name: operator_namespace
+                moduleRef:
+                  id: olm
+                  output: target_namespace
+                type: string
+                description: Namespace where operators will be installed
+              - name: app_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Namespace where operators will be installed
+              - name: name
+                type: string
+                description: The name for the instance
+                default: argocd
+                optional: true
+              - name: operator_version
+                type: string
+                description: The starting version of the CSV
+                default: v0.0.9
+                optional: true
+            version: v2.10.2
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Argo CD instance
+              - name: ingress_url
+                description: The ingress url for the Argo CD instance
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: olm
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-olm
+                    version: ">= 1.2.2"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster (openshift or kubernetes)
+              - name: ingress_subdomain
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: The subdomain for ingresses in the cluster
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: olm_namespace
+                moduleRef:
+                  id: olm
+                  output: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+              - name: operator_namespace
+                moduleRef:
+                  id: olm
+                  output: target_namespace
+                type: string
+                description: Namespace where operators will be installed
+              - name: app_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Namespace where operators will be installed
+              - name: name
+                type: string
+                description: The name for the instance
+                optional: true
+              - name: operator_version
+                type: string
+                description: The starting version of the CSV
+                optional: true
+            version: v2.10.1
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Argo CD instance
+              - name: ingress_url
+                description: The ingress url for the Argo CD instance
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-artifactory
+        name: artifactory
+        type: terraform
+        description: Module to install Artifactory into a cluster
+        tags:
+          - tools
+          - devops
+          - artifact management
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                default: artifactory-artifactory
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                default: 9.4.5
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                default: ""
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.2
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                default: artifactory-artifactory
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                default: 9.4.5
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                default: ""
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.1
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.10.0
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.9.9
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.9.8
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.9.7
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+              - name: service_account
+                type: string
+                description: The service account under which the artifactory pods should run
+                optional: true
+              - name: chart_version
+                type: string
+                description: The chart version that will be used for artifactory release
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: persistence
+                type: bool
+                description: Flag to indicate if PVCs should be used
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.9.6
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Artifactory instance
+              - name: ingress_url
+                description: The ingress url for the Artifactory instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-dashboard
+        name: dashboard
+        type: terraform
+        description: Module to install Dashboard into a cluster
+        tags:
+          - tools
+          - devops
+          - dashboard
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.11
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.11
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.10
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.10
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.9
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.9
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.8
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.8
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.6
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.7
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.6
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.6
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                default: []
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v1.3.5
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                default: 1.0.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                default: true
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.10.5
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: tool_config_maps
+                type: list(string)
+                description: The list of config maps containing connectivity information for tools
+                optional: true
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                optional: true
+              - name: chart_version
+                type: string
+                description: The helm chart version that should be installed from https://ibm-garage-cloud.github.io/toolkit-charts
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating that ssl should be enabled (OpenShift only)
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.10.4
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Catalyst Dashboard instance
+              - name: base_icon_url
+                description: The base url that serves icons for the tools
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-jenkins
+        name: jenkins
+        type: terraform
+        description: Module to install Jenkins into a cluster
+        tags:
+          - tools
+          - devops
+          - jenkins
+          - continuous integration
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The secret containing the tls certificates
+                optional: true
+              - name: server_url
+                moduleRef:
+                  id: cluster
+                  output: server_url
+                type: string
+                description: The public url of the openshift/kubernetes cluster
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where tools are deployed.
+              - name: ci_namespace
+                type: string
+                description: Name of the existing namespace where the CI deployments will be validated.
+                optional: true
+              - name: volume_capacity
+                type: string
+                description: The volume capacity of the persistence volume claim
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: helm_version
+                type: string
+                description: The version of helm chart that should be deployed
+                optional: true
+            version: v1.4.3
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Jenkins instance
+              - name: ingress_url
+                description: The ingress url for the Jenkins instance
+              - name: config_name
+                description: The name of the secret created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-pactbroker
+        name: pactbroker
+        type: terraform
+        description: Module to install Pactbroker into a cluster
+        tags:
+          - tools
+          - devops
+          - contract testing
+          - pact
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The secret containing the tls certificates
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+            version: v1.4.3
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Pact Broker instance
+              - name: ingress_url
+                description: The ingress url for the Pact Broker instance
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: config_name
+                description: The name of the ConfigMap created to store the url
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The secret containing the tls certificates
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+            version: v1.4.2
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Pact Broker instance
+              - name: ingress_url
+                description: The ingress url for the Pact Broker instance
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: config_name
+                description: The name of the ConfigMap created to store the url
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The secret containing the tls certificates
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+            version: v1.4.1
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Pact Broker instance
+              - name: ingress_url
+                description: The ingress url for the Pact Broker instance
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: config_name
+                description: The name of the ConfigMap created to store the url
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-sonarqube
+        name: sonarqube
+        type: terraform
+        description: Module to install Sonarqube into a cluster
+        tags:
+          - tools
+          - devops
+          - quality gate
+          - lint
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The secret containing the tls certificates
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: mode
+                scope: global
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: postgresql
+                scope: ignore
+                type: object({
+                description: Properties for an existing postgresql database
+                default: '{ username = password = hostname = port = database_name = external = false'
+                optional: true
+              - name: plugins
+                scope: ignore
+                type: list(string)
+                description: The list of plugins that will be installed on SonarQube
+                default: '[ https://binaries.sonarsource.com/Distribution/sonar-typescript-plugin/sonar-typescript-plugin-2.1.0.4359.jar, https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-6.5.1.22586.jar, https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.1.12157.jar, https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-2.9.0.6410.jar, https://binaries.sonarsource.com/Distribution/sonar-go-plugin/sonar-go-plugin-1.7.0.883.jar, https://github.com/checkstyle/sonar-checkstyle/releases/download/4.33/checkstyle-sonar-plugin-4.33.jar ]'
+                optional: true
+              - name: hostname
+                type: string
+                description: The hostname that will be used for the ingress/route
+                default: sonarqube
+                optional: true
+              - name: helm_version
+                type: string
+                description: The version of the helm chart that should be used
+                default: 6.4.1
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The name of the service account that should be used for the deployment
+                default: sonarqube-sonarqube
+                optional: true
+              - name: volume_capacity
+                type: string
+                description: The volume capacity of the persistence volume claim
+                default: 2Gi
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                default: ibmc-file-gold
+                optional: true
+            version: v1.9.4
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the SonarQube instance
+              - name: ingress_url
+                description: The ingress url for the SonarQube instance
+              - name: config_name
+                description: The name of the configmap created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: service_account
+                description: The service account name that was used
+              - name: namespace
+                description: The namespace where sonarqube has been installed
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The secret containing the tls certificates
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: hostname
+                type: string
+                description: The hostname that will be used for the ingress/route
+                default: sonarqube
+                optional: true
+              - name: helm_version
+                type: string
+                description: The version of the helm chart that should be used
+                default: 6.4.1
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The name of the service account that should be used for the deployment
+                default: sonarqube-sonarqube
+                optional: true
+              - name: plugins
+                type: list(string)
+                description: The list of plugins that will be installed on SonarQube
+                default: '[ https://binaries.sonarsource.com/Distribution/sonar-typescript-plugin/sonar-typescript-plugin-2.1.0.4359.jar, https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-6.5.1.22586.jar, https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-6.2.1.12157.jar, https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-2.9.0.6410.jar, https://binaries.sonarsource.com/Distribution/sonar-go-plugin/sonar-go-plugin-1.7.0.883.jar, https://github.com/checkstyle/sonar-checkstyle/releases/download/4.33/checkstyle-sonar-plugin-4.33.jar ]'
+                optional: true
+              - name: volume_capacity
+                type: string
+                description: The volume capacity of the persistence volume claim
+                default: 2Gi
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                default: ibmc-file-gold
+                optional: true
+              - name: postgresql
+                type: object({
+                description: Properties for an existing postgresql database
+                default: '{ username = password = hostname = port = database_name = external = false'
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v1.9.3
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the SonarQube instance
+              - name: ingress_url
+                description: The ingress url for the SonarQube instance
+              - name: config_name
+                description: The name of the configmap created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: service_account
+                description: The service account name that was used
+              - name: namespace
+                description: The namespace where sonarqube has been installed
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: variable "cluster_type" {   description = "The cluster type (openshift or ocp3 or ocp4 or kubernetes)" }
+                description: The cluster type (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The secret containing the tls certificates
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: hostname
+                type: string
+                description: The hostname that will be used for the ingress/route
+                optional: true
+              - name: helm_version
+                type: string
+                description: The version of the helm chart that should be used
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The name of the service account that should be used for the deployment
+                optional: true
+              - name: plugins
+                type: list(string)
+                description: The list of plugins that will be installed on SonarQube
+                optional: true
+              - name: volume_capacity
+                type: string
+                description: The volume capacity of the persistence volume claim
+                optional: true
+              - name: storage_class
+                type: string
+                description: The storage class of the persistence volume claim
+                optional: true
+              - name: postgresql
+                type: object({
+                description: Properties for an existing postgresql database
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v1.9.2
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the SonarQube instance
+              - name: ingress_url
+                description: The ingress url for the SonarQube instance
+              - name: config_name
+                description: The name of the configmap created to store the url
+              - name: secret_name
+                description: The name of the secret created to store the credentials
+              - name: service_account
+                description: The service account name that was used
+              - name: namespace
+                description: The namespace where sonarqube has been installed
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-swaggereditor
+        name: swaggereditor
+        type: terraform
+        description: Module to install Swagger editor into a cluster
+        tags:
+          - tools
+          - devops
+          - swagger editor
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster type (openshift or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+                type: string
+                description: The name of the secret containing the tls certificate values
+                default: ""
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: image_tag
+                type: string
+                description: The image version tag to use
+                default: v3.8.0
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating if oauth should be applied (only available for OpenShift)
+                default: true
+                optional: true
+              - name: chart_version
+                type: string
+                description: The version of the helm chart that will be installed
+                default: 2.0.0
+                optional: true
+            version: v1.4.2
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Swagger Editor Console instance
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: variable "cluster_type" {   description = "The cluster type (openshift or kubernetes)" }
+                description: The cluster type (openshift or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the cluster.
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: variable "tls_secret_name" {   description = "The name of the secret containing the tls certificate values"   default     = "" }
+                description: The name of the secret containing the tls certificate values
+                optional: true
+              - name: releases_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where the Helm Releases will be deployed.
+              - name: image_tag
+                type: variable "image_tag" {   description = "The image version tag to use"   default     = "v3.8.0" }
+                description: The image version tag to use
+                optional: true
+              - name: enable_sso
+                type: bool
+                description: Flag indicating if oauth should be applied (only available for OpenShift)
+                optional: true
+              - name: chart_version
+                type: string
+                description: The version of the helm chart that will be installed
+                optional: true
+            version: v1.4.1
+            outputs:
+              - name: ingress_host
+                description: The ingress host for the Swagger Editor Console instance
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-tekton
+        name: tekton
+        type: terraform
+        description: Module to install Tekton into a cluster
+        tags:
+          - tools
+          - devops
+          - tekton
+          - continuous integration
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: olm
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-olm
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: platform.ingress
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where tools are installed
+              - name: olm_namespace
+                moduleRef:
+                  id: olm
+                  output: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+                default: ""
+                optional: true
+              - name: operator_namespace
+                moduleRef:
+                  id: olm
+                  output: target_namespace
+                type: string
+                description: Namespace where operators will be installed
+                default: ""
+                optional: true
+              - name: tekton_dashboard_version
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: v0.7.1
+                optional: true
+              - name: tekton_dashboard_namespace
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: openshift-pipelines
+                optional: true
+              - name: tekton_dashboard_yaml_file_ocp
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for openshift
+                default: openshift-tekton-dashboard-release.yaml
+                optional: true
+              - name: tekton_dashboard_yaml_file_k8s
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for kubernetes
+                default: tekton-dashboard-release.yaml
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                scope: global
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v2.1.3
+            outputs:
+              - name: namespace
+                description: The namespace where Tekton dashboard was deployed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: olm
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-olm
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where tools are installed
+              - name: olm_namespace
+                moduleRef:
+                  id: olm
+                  output: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+                default: ""
+                optional: true
+              - name: operator_namespace
+                moduleRef:
+                  id: olm
+                  output: target_namespace
+                type: string
+                description: Namespace where operators will be installed
+                default: ""
+                optional: true
+              - name: tekton_dashboard_version
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: v0.7.1
+                optional: true
+              - name: tekton_dashboard_namespace
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: openshift-pipelines
+                optional: true
+              - name: tekton_dashboard_yaml_file_ocp
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for openshift
+                default: openshift-tekton-dashboard-release.yaml
+                optional: true
+              - name: tekton_dashboard_yaml_file_k8s
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for kubernetes
+                default: tekton-dashboard-release.yaml
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+                default: ""
+                optional: true
+              - name: mode
+                scope: global
+                type: string
+                description: The mode of operation for the module (setup)
+                default: ""
+                optional: true
+            version: v2.1.2
+            outputs:
+              - name: namespace
+                description: The namespace where Tekton dashboard was deployed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: olm
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-olm
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where tools are installed
+              - name: olm_namespace
+                moduleRef:
+                  id: olm
+                  output: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+              - name: operator_namespace
+                moduleRef:
+                  id: olm
+                  output: target_namespace
+                type: string
+                description: Namespace where operators will be installed
+              - name: tekton_dashboard_version
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: v0.7.1
+                optional: true
+              - name: tekton_dashboard_namespace
+                scope: ignore
+                type: string
+                description: The tekton dashboard version to install
+                default: openshift-pipelines
+                optional: true
+              - name: tekton_dashboard_yaml_file_ocp
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for openshift
+                default: openshift-tekton-dashboard-release.yaml
+                optional: true
+              - name: tekton_dashboard_yaml_file_k8s
+                scope: ignore
+                type: string
+                description: The tekton dashboard yaml file for the release for kubernetes
+                default: tekton-dashboard-release.yaml
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: Directory where the gitops repo content should be written
+              - name: mode
+                scope: global
+                type: string
+                description: The mode of operation for the module (setup)
+            version: v2.1.1
+            outputs:
+              - name: namespace
+                description: The namespace where Tekton dashboard was deployed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where tools are installed
+              - name: tekton_dashboard_version
+                type: string
+                description: The tekton dashboard version to install
+                optional: true
+              - name: tekton_dashboard_namespace
+                type: string
+                description: The tekton dashboard version to install
+                optional: true
+              - name: tekton_dashboard_yaml_file_ocp
+                type: string
+                description: The tekton dashboard yaml file for the release for openshift
+                optional: true
+              - name: tekton_dashboard_yaml_file_k8s
+                type: string
+                description: The tekton dashboard yaml file for the release for kubernetes
+                optional: true
+              - name: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+                optional: true
+              - name: operator_namespace
+                type: string
+                description: Namespace where operators will be installed
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v2.1.0
+            outputs:
+              - name: namespace
+                description: The namespace where Tekton dashboard was deployed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_ingress_hostname
+                moduleRef:
+                  id: cluster
+                  output: ingress_hostname
+                type: string
+                description: Ingress hostname of the IKS cluster.
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where tools are installed
+              - name: tekton_dashboard_version
+                type: string
+                description: The tekton dashboard version to install
+                optional: true
+              - name: tekton_dashboard_namespace
+                type: string
+                description: The tekton dashboard version to install
+                optional: true
+              - name: tekton_dashboard_yaml_file_ocp
+                type: string
+                description: The tekton dashboard yaml file for the release for openshift
+                optional: true
+              - name: tekton_dashboard_yaml_file_k8s
+                type: string
+                description: The tekton dashboard yaml file for the release for kubernetes
+                optional: true
+              - name: olm_namespace
+                type: string
+                description: Namespace where olm is installed
+                optional: true
+              - name: operator_namespace
+                type: string
+                description: Namespace where operators will be installed
+                optional: true
+              - name: gitops_dir
+                type: string
+                description: Directory where the gitops repo content should be written
+                optional: true
+              - name: mode
+                type: string
+                description: The mode of operation for the module (setup)
+                optional: true
+            version: v2.0.2
+            outputs:
+              - name: namespace
+                description: The namespace where Tekton dashboard was deployed
+        provider: tools
+      - id: github.com/cloud-native-toolkit/terraform-tools-tekton-resources
+        name: tekton-resources
+        type: terraform
+        description: Module to install Tekton resources into a cluster
+        tags:
+          - tools
+          - devops
+          - continuous integration
+          - tekton
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+                scope: ignore
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                default: tools
+                optional: true
+              - name: pre_tekton
+                scope: ignore
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                default: "false"
+                optional: true
+              - name: revision
+                scope: ignore
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                default: v2.5.0
+                optional: true
+              - name: git_url
+                scope: ignore
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                default: ' https://api.github.com/repos/ibm/ibm-garage-tekton-tasks'
+                optional: true
+            version: v2.2.13
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+                scope: ignore
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                default: tools
+                optional: true
+              - name: pre_tekton
+                scope: ignore
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                default: "false"
+                optional: true
+              - name: revision
+                scope: ignore
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                default: v2.5.0
+                optional: true
+              - name: git_url
+                scope: ignore
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                default: ' https://api.github.com/repos/ibm/ibm-garage-tekton-tasks'
+                optional: true
+            version: v2.2.12
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+                scope: ignore
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                default: tools
+                optional: true
+              - name: pre_tekton
+                scope: ignore
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                default: "false"
+                optional: true
+              - name: revision
+                scope: ignore
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                default: v2.3.0
+                optional: true
+              - name: git_url
+                scope: ignore
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                default: ' https://api.github.com/repos/ibm/ibm-garage-tekton-tasks'
+                optional: true
+            version: v2.2.11
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.10
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.9
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.8
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.7
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.6
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.5
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.4
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.3
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.2
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.1
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.2.0
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: tekton
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-tools-tekton
+                    version: ">= 2.0.1"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tekton_namespace
+                moduleRef:
+                  id: tekton
+                  output: namespace
+                type: string
+                description: The namespace where the tekton service was deployed
+              - name: resource_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tekton tasks will be deployed
+                optional: true
+              - name: pre_tekton
+                type: string
+                description: Flag indicating that the Tekton installed version is pre 0.7.0
+                optional: true
+              - name: revision
+                type: string
+                description: The revision Cloud Native Toolkit Tekton tasks and pipelines
+                optional: true
+              - name: git_url
+                type: string
+                description: The git api url containing Cloud-Native Toolkit Tekton tasks and pipelines
+                optional: true
+            version: v2.1.12
+        provider: tools
+  - category: iam
+    categoryName: IAM
+    selection: multiple
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+        name: "ibm-resource-group"
+        type: terraform
+        description: "Creates a resource groups in the account"
+        tags:
+          - ibm cloud
+          - resource group
+          - account
+        versions:
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the resource group
+              - name: provision
+                type: bool
+                description: Flag indicating that the resource group should be created
+                default: true
+                optional: true
+            version: v2.1.0
+            outputs:
+              - name: name
+                description: The name of the resource group
+              - name: id
+                description: The id of the resource group
+              - name: group
+                description: The resource group object
+          - platforms: []
+            dependencies: []
+            variables: [{name: names, type: list(string), description: List of resource group names that should be created}]
+            version: v2.0.0
+            outputs:
+              - name: names
+                description: List of resource group names
+              - name: ids
+                description: List of ids of generated resource groups
+              - name: groups
+                description: List of group names and ids
+          - platforms: []
+            dependencies: []
+            variables: [{name: names, type: list(string), description: List of resource group names that should be created}]
+            version: v1.4.1
+            outputs:
+              - name: names
+                description: List of resource group names
+              - name: ids
+                description: List of ids of generated resource groups
+              - name: groups
+                description: List of group names and ids
+          - platforms: []
+            dependencies: []
+            variables: [{name: names, type: list(string), description: List of resource group names that should be created}]
+            version: v1.4.0
+            outputs:
+              - name: names
+                description: List of resource group names
+              - name: ids
+                description: List of ids of generated resource groups
+              - name: groups
+                description: List of group names and ids
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}]
+            version: v1.3.0
+            outputs:
+              - name: names
+                description: List of resource group names
+              - name: ids
+                description: List of ids of generated resource groups
+              - name: groups
+                description: List of group names and ids
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}]
+            version: v1.2.0
+            outputs:
+              - name: names
+                description: List of resource group names
+              - name: ids
+                description: List of ids of generated resource groups
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}]
+            version: v1.1.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}]
+            version: v1.0.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: [{name: variable "my, type: variable "my, description: variable "my}, {name: 'variable" { #  type        = string #  description = "A description of my', type: string, description: 'variable" { #  type        = string #  description = "A description of my'}, {name: 'variable" #  default     = "" #}', type: 'variable" #  default     = "" #}', description: 'variable" #  default     = "" #}', optional: true}]
+            version: v0.0.0
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-access-group
+        name: ibm-access-group
+        type: terraform
+        description: Module to create ADMIN and USER access groups for a set of resource groups
+        tags:
+          - tools
+          - ibm cloud
+          - access groups
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the resource group for which the access groups will be created
+            version: v2.1.0
+            outputs:
+              - name: resource_group_name
+                description: List of resource group names
+              - name: admin_group_name
+                description: List of admin access group names
+              - name: edit_group_name
+                description: List of editor access group names
+              - name: view_group_name
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: createResourceGroups
+                scope: global
+                type: bool
+                description: Flag indicating that the resource groups should be created
+                default: false
+                optional: true
+              - name: resourceGroupNames
+                scope: global
+                type: list(string)
+                description: List of resource group names that should be created
+            version: v2.0.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: createResourceGroups
+                scope: global
+                type: bool
+                description: Flag indicating that the resource groups should be created
+                default: false
+                optional: true
+              - name: resourceGroupNames
+                scope: global
+                type: list(string)
+                description: List of resource group names that should be created
+            version: v1.2.1
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: list(string), description: List of resource group names that should be created}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, default: false, optional: true}]
+            version: v1.2.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: list(string), description: List of resource group names that should be created}, {name: region, type: string, description: The region where the container registry should be set up}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, default: false, optional: true}]
+            version: v1.1.2
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: list(string), description: List of resource group names that should be created}, {name: region, type: string, description: The region where the container registry should be set up}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, default: false, optional: true}]
+            version: v1.1.1
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: list(string), description: List of resource group names that should be created}, {name: region, type: string, description: The region where the container registry should be set up}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, default: false, optional: true}]
+            version: v1.1.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of editor access group names (**Deprecated** use editGroupNames instead
+              - name: editGroupNames
+                description: List of editor access group names
+              - name: viewGroupNames
+                description: List of viewer access group names
+          - platforms: []
+            dependencies: []
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}, {name: region, type: string, description: The region where the container registry should be set up}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, optional: true}]
+            version: v1.0.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of user access group names
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: [{name: resourceGroupNames, type: string, description: Comma-separated list of resource group names that should be created}, {name: region, type: string, description: The region where the container registry should be set up}, {name: createResourceGroups, type: bool, description: Flag indicating that the resource groups should be created, optional: true}]
+            version: v0.1.0
+            outputs:
+              - name: resourceGroupNames
+                description: List of resource group names
+              - name: adminGroupNames
+                description: List of admin access group names
+              - name: userGroupNames
+                description: List of user access group names
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: [{name: variable "my, type: variable "my, description: variable "my}, {name: 'variable" { #  type        = string #  description = "A description of my', type: string, description: 'variable" { #  type        = string #  description = "A description of my'}, {name: 'variable" #  default     = "" #}', type: 'variable" #  default     = "" #}', description: 'variable" #  default     = "" #}', optional: true}]
+            version: v0.0.0
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-account-users
+        name: ibm-account-users
+        type: terraform
+        description: Module to invite users to the account
+        provider: ibm
+        tags:
+          - tools
+          - devops
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: users
+                scope: module
+                type: list(string)
+                description: List of users who should be invited to the account
+            version: v1.1.0
+            outputs:
+              - name: users
+                description: The list of users who have been invited
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: users
+                scope: module
+                type: string
+                description: Comma-separated list of users who should be invited to the account
+            version: v1.0.0
+            outputs:
+              - name: users
+                description: The list of users who have been invited
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+      - id: github.com/cloud-native-toolkit/terraform-ibm-add-access-group-users
+        name: ibm-add-access-group-users
+        type: terraform
+        description: Module to add users to provided access groups in an IBM Cloud account
+        provider: ibm
+        tags:
+          - tools
+          - devops
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables: [{name: access_groups, type: list(string), description: List of the groups to which the users should be added}, {name: users, type: list(string), description: List of users}]
+            version: v1.0.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+  - category: image-registry
+    categoryName: Image Registry
+    selection: single
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-image-registry
+        name: ibm-image-registry
+        alias: registry
+        type: terraform
+        description: Module to set up a namespace in the IBM Container Registry and configure the cluster
+        tags:
+          - tools
+          - devops
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                default: ""
+                optional: true
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                default: ""
+                optional: true
+              - name: region
+                scope: global
+                type: string
+                description: The region for the image registry been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the registry url should be created with private endpoints
+                default: "true"
+                optional: true
+            version: v2.0.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                default: ""
+                optional: true
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                default: ""
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the registru url should be created with private endpoints
+                default: "true"
+                optional: true
+            version: v1.5.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                default: ""
+                optional: true
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                default: ""
+                optional: true
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.4.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.3.6
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.3.5
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+              - name: registry_user
+                scope: ignore
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                default: iamapikey
+                optional: true
+              - name: registry_password
+                scope: ignore
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+              - name: cluster_region
+                scope: global
+                alias: region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: apply
+                scope: module
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.3.4
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.3.3
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.3.2
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.3.1
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.3.0
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: resource_group_name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: registry_namespace
+                type: string
+                description: The namespace that will be created in the IBM Cloud image registry. If not provided the value will default to the resource group
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username to authenticate to the IBM Container Registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password (API key) to authenticate to the IBM Container Registry. If not provided the value will default to `var.ibmcloud_api_key`
+                optional: true
+              - name: cluster_region
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: ibmcloud_api_key
+                type: string
+                description: The IBM Cloud api token
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.2.3
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ocp-image-registry
+        name: ocp-image-registry
+        alias: registry
+        type: terraform
+        provider: k8s
+        description: Module to set up the internal OCP Image Registry in a cluster
+        tags:
+          - tools
+          - devops
+          - ocp
+          - image registry
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: config_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+            version: v1.4.0
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: config_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+            version: v1.3.4
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: config_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+            version: v1.3.3
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: config_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+            version: v1.3.2
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: config_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: apply
+                scope: global
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+            version: v1.3.1
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.3.0
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.2.2
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.2.1
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+      - id: github.com/cloud-native-toolkit/terraform-k8s-image-registry
+        name: k8s-image-registry
+        alias: registry
+        type: terraform
+        description: Sets up an external image registry for use within the cluster
+        tags:
+          - tools
+          - devops
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace in the image registry where images will be stored. This value can contain slashes.
+              - name: registry_host
+                scope: global
+                type: string
+                description: The host name of the image registry
+              - name: registry_url
+                scope: global
+                type: string
+                description: The public url of the image registry
+              - name: registry_user
+                scope: global
+                type: string
+                description: The username for the image registry
+              - name: registry_password
+                scope: global
+                type: string
+                description: The password for the image registry
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.1.7
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: registry_namespace
+                scope: global
+                type: string
+                description: The namespace in the image registry where images will be stored. This value can contain slashes.
+              - name: registry_host
+                scope: global
+                type: string
+                description: The host name of the image registry
+              - name: registry_url
+                scope: global
+                type: string
+                description: The public url of the image registry
+              - name: registry_user
+                scope: global
+                type: string
+                description: The username for the image registry
+              - name: registry_password
+                scope: global
+                type: string
+                description: The password for the image registry
+              - name: apply
+                scope: ignore
+                type: bool
+                description: Flag indicating that the module should be applied
+                default: true
+                optional: true
+            version: v1.1.6
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: registry_namespace
+                type: string
+                description: The namespace in the image registry where images will be stored. This value can contain slashes.
+                optional: true
+              - name: registry_host
+                type: string
+                description: The host name of the image registry
+                optional: true
+              - name: registry_url
+                type: string
+                description: The public url of the image registry
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username for the image registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password for the image registry
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.1.5
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: registry_namespace
+                type: string
+                description: The namespace in the image registry where images will be stored. This value can contain slashes.
+                optional: true
+              - name: registry_host
+                type: string
+                description: The host name of the image registry
+                optional: true
+              - name: registry_url
+                type: string
+                description: The public url of the image registry
+                optional: true
+              - name: registry_user
+                type: string
+                description: The username for the image registry
+                optional: true
+              - name: registry_password
+                type: string
+                description: The password for the image registry
+                optional: true
+              - name: cluster_type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: apply
+                type: bool
+                description: Flag indicating that the module should be applied
+                optional: true
+            version: v1.1.4
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: k8s
+  - category: infrastructure
+    categoryName: Infrastructure
+    selection: indirect
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-k8s-namespace
+        name: namespace
+        description: Creates a namespace in the cluster
+        platforms:
+          - kubernetes
+          - ocp3
+          - ocp4
+        tags:
+          - infrastructure
+          - namespace
+        versions:
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: platform.tls_secret
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v3.0.1
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v3.0.0
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+                default: ""
+                optional: true
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v2.7.3
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+                default: ""
+                optional: true
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v2.7.2
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v2.7.1
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v2.7.0
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+              - name: name
+                scope: module
+                type: string
+                description: The namespace that should be created
+            version: v2.6.1
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+                optional: true
+              - name: name
+                type: string
+                description: The namespace that should be created
+            version: v2.6.0
+            outputs:
+              - name: name
+                description: Namespace name
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+              - name: tls_secret_name
+                moduleRef:
+                  id: cluster
+                  output: tls_secret_name
+                type: string
+                description: The name of the secret containing the tls certificate for the cluster
+                optional: true
+              - name: name
+                type: string
+                description: The namespace that should be created
+            version: v2.5.2
+            outputs:
+              - name: name
+                description: Namespace name
+        provider: k8s
+      - id: github.com/cloud-native-toolkit/terraform-k8s-olm
+        name: olm
+        type: terraform
+        description: Installs Operator Lifecycle Manager in the cluster
+        platforms:
+          - kubernetes
+          - ocp3
+          - ocp4
+        tags:
+          - operators
+        versions:
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: type_code
+                type: string
+                description: The type of cluster (openshift or kubernetes)
+              - name: cluster_version
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: version
+                type: string
+                description: The version of cluster
+              - name: olm_version
+                scope: ignore
+                type: string
+                description: The version of olm that will be installed
+                default: 0.17.0
+                optional: true
+            version: v1.2.4
+            outputs:
+              - name: olm_namespace
+                description: Namespace where OLM is running. The value will be different between OCP 4.3 and IKS/OCP 3.11
+              - name: target_namespace
+                description: Namespace where operatoes will be installed
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: type_code
+                type: string
+                description: The type of cluster (openshift or kubernetes)
+              - name: cluster_version
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: version
+                type: string
+                description: The version of cluster
+              - name: olm_version
+                scope: ignore
+                type: string
+                description: The version of olm that will be installed
+                default: 0.17.0
+                optional: true
+            version: v1.2.3
+            outputs:
+              - name: olm_namespace
+                description: Namespace where OLM is running. The value will be different between OCP 4.3 and IKS/OCP 3.11
+              - name: target_namespace
+                description: Namespace where operatoes will be installed
+          - dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: type_code
+                type: string
+                description: The type of cluster (openshift or kubernetes)
+              - name: cluster_version
+                moduleRef:
+                  id: cluster
+                  output: platform
+                  path: version
+                type: string
+                description: The version of cluster
+              - name: olm_version
+                type: string
+                description: The version of olm that will be installed
+                optional: true
+            version: v1.2.2
+            outputs:
+              - name: olm_namespace
+                description: Namespace where OLM is running. The value will be different between OCP 4.3 and IKS/OCP 3.11
+              - name: target_namespace
+                description: Namespace where operatoes will be installed
+        provider: k8s
+      - id: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+        name: ibm-cp-catalog
+        type: terraform
+        description: Base install of the Cloud Pak for Integration operator catalog and pull secrets
+        tags:
+          - tools
+          - devops
+        provider: k8s
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                default: default
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                default: ""
+                optional: true
+            version: v1.3.1
+            outputs:
+              - name: name
+                description: The name of the catalog that was installed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                default: default
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                default: ""
+                optional: true
+            version: v1.3.0
+            outputs:
+              - name: name
+                description: The name of the catalog that was installed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                default: default
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                default: ""
+                optional: true
+            version: v1.2.0
+            outputs:
+              - name: name
+                description: The name of the catalog that was installed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                default: default
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                default: ""
+                optional: true
+            version: v1.1.0
+            outputs:
+              - name: name
+                description: The name of the catalog that was installed
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                optional: true
+            version: v1.0.4
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: Cluster config file for Kubernetes cluster.
+              - name: release_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: Name of the existing namespace where Pact Broker will be deployed.
+                optional: true
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: entitlement_key
+                scope: module
+                type: string
+                description: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
+                optional: true
+            version: v1.0.3
+      - id: github.com/cloud-native-toolkit/terraform-ibm-cp-platform-navigator
+        name: ibm-cp-platform-navigator
+        type: terraform
+        description: Module to install the Cloud Pak Platform Navigator
+        tags:
+          - tools
+          - devops
+        provider: k8s
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: cloud-pak
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+            version: v1.2.2
+            outputs:
+              - name: name
+                description: Platform navigator instance name
+              - name: namespace
+                description: Platform navigator instance namespace
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: cloud-pak
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+            version: v1.2.1
+            outputs:
+              - name: name
+                description: Platform navigator instance name
+              - name: namespace
+                description: Platform navigator instance namespace
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: cloud-pak
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+            version: v1.2.0
+            outputs:
+              - name: name
+                description: Platform navigator instance name
+              - name: namespace
+                description: Platform navigator instance namespace
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: cloud-pak
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+            version: v1.1.0
+            outputs:
+              - name: name
+                description: Platform navigator instance name
+              - name: namespace
+                description: Platform navigator instance namespace
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: cloud-pak
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+            version: v1.0.0
+            outputs:
+              - name: name
+                description: Platform navigator instance name
+              - name: namespace
+                description: Platform navigator instance namespace
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+  - category: middleware
+    categoryName: Middleware
+    selection: multiple
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-appid
+        name: ibm-appid
+        type: terraform
+        description: Provisions the IBM Cloud AppId service
+        tags:
+          - tools
+          - devops
+        versions:
+          - platforms: []
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: namespaces
+                scope: module
+              - name: namespace_count
+                scope: module
+              - name: tags
+                scope: module
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                scope: module
+                type: string
+                description: The type of plan the service instance should run under (lite or graduated-tier)
+                default: graduated-tier
+                optional: true
+            version: v1.2.0
+          - platforms: []
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: Id of the cluster
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: namespaces
+                scope: module
+                type: list(string)
+                description: Namespaces
+                optional: true
+              - name: namespace_count
+                scope: module
+                type: number
+                description: The number of namespaces
+                optional: true
+              - name: tags
+                scope: module
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: plan
+                scope: module
+                type: string
+                description: The type of plan the service instance should run under (lite or graduated-tier)
+                optional: true
+            version: v1.1.1
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-key-protect
+        name: key-protect
+        type: terraform
+        description: Module to provision Key Protect
+        tags:
+          - tools
+          - vault
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The api key for IBM Cloud access
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the service should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (tiered-pricing)
+                default: tiered-pricing
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+                default: true
+                optional: true
+            version: v2.0.2
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The api key for IBM Cloud access
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the service should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (tiered-pricing)
+                default: tiered-pricing
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+                default: true
+                optional: true
+            version: v2.0.1
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The api key for IBM Cloud access
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the service should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (tiered-pricing)
+                default: tiered-pricing
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+            version: v2.0.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The api key for IBM Cloud access
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the service should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (tiered-pricing)
+                default: tiered-pricing
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+            version: v1.4.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (tiered-pricing)
+                default: tiered-pricing
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                type: string
+                description: The api key for IBM Cloud access
+                default: ""
+                optional: true
+            version: v1.3.2
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-mongodb
+        name: ibm-mongodb
+        type: terraform
+        description: Module to provision Databases for MongoDB instance
+        tags:
+          - tools
+          - infrastructure
+          - mongodb
+          - saas
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            version: v1.1.1
+            variables:
+              - name: resource_group_name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (standard)
+                default: standard
+                optional: true
+              - name: role
+                type: string
+                description: The role of the generated credential (Viewer, Administrator, Operator, Editor)
+                default: Editor
+                optional: true
+              - name: key-protect-region
+                type: string
+                description: The region where the Key Protect instance has been provisioned. If not provided defaults to the same region as the MongoDB instance
+                default: ""
+                optional: true
+              - name: key-protect-resource-group
+                type: string
+                description: The resource group where the Key Protect instance has been provisioned. If not provided defaults to the same resource group as the MongoDB instance
+                default: ""
+                optional: true
+              - name: key-protect-name
+                type: string
+                description: The name of the Key Protect instance
+                default: ""
+                optional: true
+              - name: key-protect-key
+                type: string
+                description: The name of the key in the Key Protect instance
+                default: ""
+                optional: true
+              - name: authorize-kms
+                type: bool
+                description: Flag indicating that the authorization for MongoDB to read keys in the KMS should be created
+                default: false
+                optional: true
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            version: v1.1.0
+            variables:
+              - name: resource_group_name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (standard)
+                optional: true
+              - name: role
+                type: string
+                description: The role of the generated credential (Viewer, Administrator, Operator, Editor)
+                optional: true
+              - name: key-protect-region
+                type: string
+                description: The region where the Key Protect instance has been provisioned. If not provided defaults to the same region as the MongoDB instance
+                optional: true
+              - name: key-protect-resource-group
+                type: string
+                description: The resource group where the Key Protect instance has been provisioned. If not provided defaults to the same resource group as the MongoDB instance
+                optional: true
+              - name: key-protect-name
+                type: string
+                description: The name of the Key Protect instance
+                optional: true
+              - name: key-protect-key
+                type: string
+                description: The name of the key in the Key Protect instance
+                optional: true
+              - name: authorize-kms
+                type: bool
+                description: Flag indicating that the authorization for MongoDB to read keys in the KMS should be created
+                optional: true
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-object-storage
+        name: ibm-object-storage
+        alias: cos
+        type: terraform
+        description: |
+          Module to work with an IBM Cloud Object Storage instance. If the `provision` flag is true then an new instance
+          of IBM Cloud Object Storage is provisioned. Otherwise, the module will find an existing instance with the
+          provided name and create a credential. The name and id of the Object Storage instance as well as the name and id
+          of the credential instance are exported from the module for use by other modules.
+        tags:
+          - tools
+          - infrastructure
+          - object storage
+          - saas
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+                default: global
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite or standard)
+                default: standard
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+                default: true
+                optional: true
+            version: v3.0.2
+            outputs:
+              - name: name
+                description: The Object Storage instance name
+              - name: id
+                description: The Object Storage instance id
+              - name: location
+                description: The Object Storage instance location
+              - name: key_name
+                description: The name of the credential provisioned for the Object Storage instance
+              - name: key_id
+                description: The name of the credential provisioned for the Object Storage instance
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+                default: global
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite or standard)
+                default: standard
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+                default: true
+                optional: true
+            version: v3.0.1
+            outputs:
+              - name: name
+                description: The Object Storage instance name
+              - name: id
+                description: The Object Storage instance id
+              - name: location
+                description: The Object Storage instance location
+              - name: key_name
+                description: The name of the credential provisioned for the Object Storage instance
+              - name: key_id
+                description: The name of the credential provisioned for the Object Storage instance
+          - platforms: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+                default: global
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite or standard)
+                default: standard
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+            version: v3.0.0
+            outputs:
+              - name: name
+                description: The Object Storage instance name
+              - name: id
+                description: The Object Storage instance id
+              - name: location
+                description: The Object Storage instance location
+              - name: key_name
+                description: The name of the credential provisioned for the Object Storage instance
+              - name: key_id
+                description: The name of the credential provisioned for the Object Storage instance
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+                default: global
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite or standard)
+                default: standard
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+            version: v2.1.0
+            outputs:
+              - name: name
+                description: The Object Storage instance name
+              - name: id
+                description: The Object Storage instance id
+              - name: location
+                description: The Object Storage instance location
+              - name: key_name
+                description: The name of the credential provisioned for the Object Storage instance
+              - name: key_id
+                description: The name of the credential provisioned for the Object Storage instance
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            version: v2.0.2
+            variables:
+              - name: resource_group_name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+                default: global
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite or standard)
+                default: standard
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that key-protect instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-cp-app-connect
+        name: cp-app-connect
+        type: terraform
+        description: Module to install App Connect in the cluster
+        tags:
+          - tools
+          - devops
+        provider: k8s
+        versions:
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.0.0"
+              - id: platform-navigator
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-platform-navigator
+                    version: ">= 1.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: platform-navigator-name
+                moduleRef:
+                  id: platform-navigator
+                  output: name
+                type: string
+                description: The name of the platform navigator instance
+                default: ""
+                optional: true
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: app-connect
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: storage_class
+                scope: global
+                type: string
+                description: The storage class that should be used for the dashboard and designer
+                default: ""
+                optional: true
+              - name: dashboard
+                type: bool
+                description: Flag to install the dashboard
+                default: true
+                optional: true
+            version: v1.0.1
+          - platforms:
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: cp-catalog
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-catalog
+                    version: ">= 1.7.0"
+              - id: platform-navigator
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-cp-platform-navigator
+                    version: ">= 1.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster
+                default: ocp4
+                optional: true
+              - name: cluster_config_file
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The location of the kube config
+              - name: catalog_name
+                moduleRef:
+                  id: cp-catalog
+                  output: name
+                type: string
+                description: The name of the Cloud Pak catalog
+                default: ibm-operator-catalog
+                optional: true
+              - name: platform-navigator-name
+                moduleRef:
+                  id: platform-navigator
+                  output: name
+                type: string
+                description: The name of the platform navigator instance
+                default: ""
+                optional: true
+              - name: namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: app-connect
+                type: string
+                description: The namespace where the platform navigator should be installed
+                default: cp4i
+                optional: true
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: storage_class
+                scope: global
+                type: string
+                description: The storage class that should be used for the dashboard and designer
+                default: ""
+                optional: true
+              - name: dashboard
+                type: bool
+                description: Flag to install the dashboard
+                default: true
+                optional: true
+            version: v1.0.0
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+  - category: network
+    categoryName: Network
+    selection: multiple
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-vpc
+        name: ibm-vpc
+        type: terraform
+        description: Provisions the IBM Cloud VPC instance with network acls
+        tags:
+          - infrastructure
+          - networking
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: ignore
+                type: number
+                description: (Deprecated) Number of subnets to create
+                default: 0
+                optional: true
+              - name: subnets
+                scope: module
+                type: list(object({label = string}))
+                description: The labeled subnets that should be created. Each entry in the list represents a different subnet
+                default: []
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.5.2
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The total number of subnets for the vpc
+              - name: subnet_label_counts
+                description: The number of subnets for each label. e.g. [{label = 'default', count = 2}, {label = 'test', count = 1}]
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+              - name: subnets
+                description: List of subnet objects that contain the subnet id and label, e.g. [{label='', id=''}]
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: ignore
+                type: number
+                description: (Deprecated) Number of subnets to create
+                default: 0
+                optional: true
+              - name: subnets
+                scope: module
+                type: list(object({
+                description: The labeled subnets that should be created. Each entry in the list represents a different subnet
+                default: []
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.5.1
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The total number of subnets for the vpc
+              - name: subnet_label_counts
+                description: The number of subnets for each label. e.g. [{label = 'default', count = 2}, {label = 'test', count = 1}]
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+              - name: subnets
+                description: List of subnet objects that contain the subnet id and label, e.g. [{label='', id=''}]
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: ignore
+                type: number
+                description: (Deprecated) Number of subnets to create
+                default: 0
+                optional: true
+              - name: subnets
+                scope: module
+                type: list(object({
+                description: The labeled subnets that should be created. Each entry in the list represents a different subnet
+                default: []
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.5.0
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The total number of subnets for the vpc
+              - name: subnet_label_counts
+                description: The number of subnets for each label. e.g. [{label = 'default', count = 2}, {label = 'test', count = 1}]
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+              - name: subnets
+                description: List of subnet objects that contain the subnet id and label, e.g. [{label='', id=''}]
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.4.1
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.4.0
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.3.2
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.3.1
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.3.0
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.2.0
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: subnet_count
+                description: The number of subnets for the vpc
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.1.1
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name
+                scope: ignore
+                type: string
+                description: The name of the vpc instance
+                default: ""
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: subnet_count
+                scope: module
+                type: number
+                description: Number of subnets for region
+                default: 1
+                optional: true
+              - name: public_gateway
+                scope: module
+                type: bool
+                description: Flag indicating that a public gateway should be created
+                default: true
+                optional: true
+            version: v1.1.0
+            outputs:
+              - name: name
+                description: The name of the vpc instance
+              - name: id
+                description: The id of the vpc instance
+              - name: zone_names
+                description: The list of zone names that into which subnets were created
+              - name: subnet_ids
+                description: The list of subnet ids
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-vpc-ssh
+        name: ibm-vpc-ssh
+        alias: ssh
+        type: terraform
+        description: Module to register an ssh key into the IBM Cloud infrastructure for use in securely accessing VPC resources
+        tags:
+          - vpc
+          - ssh
+          - infrastructure
+          - security
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: 'Name of resource group in which to create the ssh key instance. '
+              - name: region
+                scope: global
+                type: string
+                description: Region
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: name_prefix
+                scope: global
+                type: string
+                description: (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                default: ""
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                default: ""
+                optional: true
+              - name: public_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: ""
+                optional: true
+              - name: private_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: ""
+                optional: true
+            version: v1.0.4
+            outputs:
+              - name: id
+                description: The id of the ssh key
+              - name: public_key
+                description: The public key value
+              - name: private_key
+                description: The private key value
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: 'Name of resource group in which to create the ssh key instance. '
+              - name: region
+                scope: global
+                type: string
+                description: Region
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: name_prefix
+                scope: global
+                type: string
+                description: (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                default: description = (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                default: description = (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                optional: true
+              - name: public_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+              - name: private_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+            version: v1.0.3
+            outputs:
+              - name: id
+                description: The id of the ssh key
+              - name: public_key
+                description: The public key value
+              - name: private_key
+                description: The private key value
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: 'Name of resource group in which to create the ssh key instance. '
+              - name: region
+                scope: global
+                type: string
+                description: Region
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: name_prefix
+                scope: global
+                type: string
+                description: (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                default: description = (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                default: description = (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                optional: true
+              - name: public_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+              - name: private_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+            version: v1.0.2
+            outputs:
+              - name: id
+                description: The id of the ssh key
+              - name: public_key
+                description: The public key value
+              - name: private_key
+                description: The private key value
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: 'Name of resource group in which to create the ssh key instance. '
+              - name: region
+                scope: global
+                type: string
+                description: Region
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: name_prefix
+                scope: global
+                type: string
+                description: (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                default: description = (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                default: description = (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                optional: true
+              - name: public_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+              - name: private_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+            version: v1.0.1
+            outputs:
+              - name: id
+                description: The id of the ssh key
+              - name: public_key
+                description: The public key value
+              - name: private_key
+                description: The private key value
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: 'Name of resource group in which to create the ssh key instance. '
+              - name: region
+                scope: global
+                type: string
+                description: Region
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: name_prefix
+                scope: global
+                type: string
+                description: (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                default: description = (Optional) Prefix used to name all resources. If not provided then resource_group_name is used.
+                optional: true
+              - name: name
+                scope: ignore
+                type: string
+                description: (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                default: description = (Optional) Name given to the ssh key instance. If not provided it will be generated using prefix_name
+                optional: true
+              - name: public_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+              - name: private_key
+                type: string
+                description: (Optional) The public key provided for the ssh key. If not provided it will be generated
+                default: description = (Optional) The public key provided for the ssh key. If not provided it will be generated
+                optional: true
+            version: v1.0.0
+            outputs:
+              - name: id
+                description: The id of the ssh key
+              - name: public_key
+                description: The public key value
+              - name: private_key
+                description: The private key value
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-vsi-bastion
+        name: vsi-bastion
+        type: terraform
+        description: Module to provision Basion in a vsi image
+        tags:
+          - infrastructure
+          - network
+          - vpc
+          - vpn
+        versions:
+          - platforms: []
+            dependencies:
+              - id: vpc
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+                    version: ">= 1.0.0"
+            variables:
+              - name: vpc_name
+                moduleRef:
+                  id: vpc
+                  output: name
+                type: string
+                description: The name of the vpc instance
+              - name: subnet_count
+                moduleRef:
+                  id: vpc
+                  output: subnet_count
+                type: number
+                description: The number of subnets on the vpc instance
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: The name of the IBM Cloud resource group where the cluster will be created/can be found.
+              - name: region
+                scope: global
+                type: string
+                description: The IBM Cloud region where the cluster will be/has been installed.
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The name of the vpc resource
+                default: ""
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api token
+              - name: tags
+                scope: module
+                type: list(string)
+                description: List of tags
+                default: []
+                optional: true
+              - name: openvpn_server_network
+                scope: ignore
+                type: string
+                default: 10.66.0.0
+                optional: true
+            version: v1.0.0
+            outputs:
+              - name: output vpc_name {   value = data.ibm_is_vpc.vpc.name }
+                description: output vpc_name {   value = data.ibm_is_vpc.vpc.name }
+              - name: output bastion_ip {   value = module.bastion.bastion_public_ip }
+                description: output bastion_ip {   value = module.bastion.bastion_public_ip }
+              - name: output bastion_private_ip {   value = module.bastion.bastion_private_ip }
+                description: output bastion_private_ip {   value = module.bastion.bastion_private_ip }
+              - name: 'output instance_ips {   value = [     for instance in local.instances : instance.primary_network_interface.0.primary_ipv4_address   ] }'
+                description: 'output instance_ips {   value = [     for instance in local.instances : instance.primary_network_interface.0.primary_ipv4_address   ] }'
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: []
+            version: v0.0.0
+        provider: vsi
+  - category: source-control
+    categoryName: Source Control
+    selection: single
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-k8s-source-control
+        name: source-control
+        alias: git
+        type: terraform
+        description: Module to install Source control into a cluster
+        tags:
+          - tools
+          - devops
+          - source control
+          - git
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-ocp-vpc
+                    version: ">= 1.0.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: platform.type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+                default: ""
+                optional: true
+              - name: type
+                scope: module
+                type: string
+                description: The type of source control system (github or gitlab) currently
+              - name: url
+                scope: module
+                type: string
+                description: The url to the git host (base git host, org, or repo url)
+            version: v1.2.4
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: type
+                scope: module
+                type: string
+                description: The type of source control system (github or gitlab) currently
+              - name: url
+                scope: module
+                type: string
+                description: The url to the git host (base git host, org, or repo url)
+            version: v1.2.3
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                default: ocp4
+                optional: true
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                scope: global
+                type: string
+                description: The directory where the gitops configuration should be stored
+              - name: type
+                scope: module
+                type: string
+                description: The type of source control system (github or gitlab) currently
+              - name: url
+                scope: module
+                type: string
+                description: The url to the git host (base git host, org, or repo url)
+            version: v1.2.2
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_type_code
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The cluster_type of the cluster
+                optional: true
+              - name: config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the kube config
+              - name: cluster_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace in the cluster where the configuration should be created (e.g. tools)
+              - name: gitops_dir
+                type: string
+                description: The directory where the gitops configuration should be stored
+                optional: true
+              - name: type
+                type: string
+                description: The type of source control system (github or gitlab) currently
+              - name: url
+                type: string
+                description: The url to the git host (base git host, org, or repo url)
+            version: v1.2.1
+            outputs:
+              - name: output "my
+                description: output "my
+              - name: 'output" { #  description = "Description of my'
+                description: 'output" { #  description = "Description of my'
+              - name: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+                description: 'output" #  value       = "value" #  depends_on  = [<some resource>] #}'
+        provider: k8s
+  - category: sre
+    categoryName: SRE tools
+    selection: multiple
+    modules:
+      - id: github.com/cloud-native-toolkit/terraform-ibm-activity-tracker
+        name: ibm-activity-tracker
+        type: terraform
+        description: Provisions the IBM Cloud hosted Activity Tracker service
+        tags:
+          - sre
+          - account
+          - ibm cloud
+          - activity tracker
+        versions:
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that the instance should be provisioned
+                default: false
+                optional: true
+            version: v2.1.1
+          - platforms: []
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that the instance should be provisioned
+                default: false
+                optional: true
+            version: v2.1.0
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that the instance should be provisioned
+                default: false
+                optional: true
+            version: v2.0.0
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that the instance should be provisioned
+                optional: true
+            version: v1.1.4
+            outputs: []
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Resource group where the cluster has been provisioned.
+              - name: resource_location
+                scope: global
+                alias: region
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that the instance should be provisioned
+                optional: true
+            version: v1.1.3
+            outputs: []
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-logdna
+        name: logdna
+        type: terraform
+        description: Module to provision a LogDNA instance
+        tags:
+          - tools
+          - devops
+          - logdna
+          - logging
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.2.0
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: guid
+                description: The guid of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+              - name: key_name
+                description: The name of the key provisioned for the LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.2
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.1
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.0
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+                optional: true
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+                optional: true
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The identifier for the cluster
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: platform.kubeconfig
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+            version: v3.0.1
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The identifier for the cluster
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: platform.kubeconfig
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+            version: v3.0.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The identifier for the cluster
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: platform.kubeconfig
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+            version: v2.7.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The identifier for the cluster
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: platform.kubeconfig
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+            version: v2.6.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The identifier for the cluster
+                default: ""
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster
+                default: ""
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster referenced by cluster_id (openshift or ocp3 or ocp4 or kubernetes)
+                default: ""
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+                optional: true
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+            version: v2.5.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The identifier for the cluster
+                default: ""
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster
+                default: ""
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster referenced by cluster_id (openshift or ocp3 or ocp4 or kubernetes)
+                default: ""
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+                optional: true
+              - name: resource_group_name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                default: 7-day
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                default: logdna-agent
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                default: ""
+                optional: true
+              - name: private_endpoint
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+            version: v2.4.4
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The identifier for the cluster
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster referenced by cluster_id (openshift or ocp3 or ocp4 or kubernetes)
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                optional: true
+              - name: resource_group_name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                optional: true
+              - name: service_account_name
+                type: string
+                description: The service account that the logdna agent should run under
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore to synchronize activities between modules
+                optional: true
+              - name: private_endpoint
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                optional: true
+            version: v2.4.3
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "logdna"   depends_on = [helm_release.logdna] }
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-sysdig
+        name: sysdig
+        type: terraform
+        description: Module to set up the Sysdig into a cluster
+        tags:
+          - tools
+          - devops
+          - monitoring
+        versions:
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.2.0
+            outputs:
+              - name: id
+                description: The id of the provisioned Sysdig instance.
+              - name: name
+                description: The name of the provisioned Sysdig instance.
+              - name: guid
+                description: The id of the provisioned Sysdig instance.
+              - name: key_name
+                description: The name of the key provisioned for the Sysdig instance.
+              - name: access_key
+                description: The access key for the Sysdig instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.3
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+                default: true
+                optional: true
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.2
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms: []
+            dependencies: []
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.1
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+                optional: true
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+                optional: true
+            variables:
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+            version: v3.1.0
+            outputs:
+              - name: id
+                description: The id of the provisioned LogDNA instance.
+              - name: name
+                description: The name of the provisioned LogDNA instance.
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+                optional: true
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+                optional: true
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+            version: v3.0.1
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+            version: v3.0.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+            version: v2.7.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                optional: true
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                optional: true
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                optional: true
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                optional: true
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+            version: v2.6.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+                default: ""
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+                optional: true
+              - name: resource_group_name
+                scope: global
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: region
+                scope: global
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                scope: global
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: private_endpoint
+                scope: global
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+            version: v2.5.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                default: ""
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                default: ""
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+                default: ""
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                default: ""
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                default: default
+                optional: true
+              - name: resource_group_name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                default: ""
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                default: graduated-tier
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                default: []
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                default: ""
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                default: ibm-observe
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                default: ""
+                optional: true
+              - name: private_endpoint
+                type: string
+                description: Flag indicating that the agent should be created with private endpoints
+                default: "true"
+                optional: true
+            version: v2.4.0
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+          - platforms:
+              - kubernetes
+              - ocp3
+              - ocp4
+            dependencies:
+              - id: cluster
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+                    version: ">= 1.7.0"
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+                    version: ">= 2.0.0"
+              - id: namespace
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+                    version: ">= 2.1.0"
+            variables:
+              - name: cluster_id
+                moduleRef:
+                  id: cluster
+                  output: id
+                type: string
+                description: The id of the cluster into which the sysdig instance should be bound
+                optional: true
+              - name: cluster_name
+                moduleRef:
+                  id: cluster
+                  output: name
+                type: string
+                description: The name of the cluster into which the sysdig instance should be bound
+                optional: true
+              - name: cluster_type
+                moduleRef:
+                  id: cluster
+                  output: type_code
+                type: string
+                description: The type of cluster that should be created (openshift or ocp3 or ocp4 or kubernetes)
+                optional: true
+              - name: cluster_config_file_path
+                moduleRef:
+                  id: cluster
+                  output: config_file_path
+                type: string
+                description: The path to the config file for the cluster
+                optional: true
+              - name: tools_namespace
+                moduleRef:
+                  id: namespace
+                  output: name
+                  discriminator: tools
+                type: string
+                description: The namespace where the tools have been deployed (where the configmap should be created)
+                optional: true
+              - name: resource_group_name
+                type: string
+                description: Existing resource group where the IKS cluster will be provisioned.
+              - name: resource_location
+                type: string
+                description: Geographic location of the resource (e.g. us-south, us-east)
+              - name: name_prefix
+                type: string
+                description: The prefix name for the service. If not provided it will default to the resource group name
+                optional: true
+              - name: plan
+                type: string
+                description: The type of plan the service instance should run under (trial or graduated-tier)
+                optional: true
+              - name: tags
+                type: list(string)
+                description: Tags that should be applied to the service
+                optional: true
+              - name: provision
+                type: bool
+                description: Flag indicating that logdna instance should be provisioned
+              - name: name
+                type: string
+                description: The name that should be used for the service, particularly when connecting to an existing service. If not provided then the name will be defaulted to {name prefix}-{service}
+                optional: true
+              - name: namespace
+                type: string
+                description: The namespace where the agent should be deployed
+                optional: true
+              - name: sync
+                type: string
+                description: Semaphore value to sync up modules
+                optional: true
+            version: v2.3.3
+            outputs:
+              - name: sync
+                description: output "sync" {   value = "sysdig"   depends_on = [helm_release.sysdig] }
+        provider: ibm
+      - id: github.com/cloud-native-toolkit/terraform-ibm-scc-collector
+        name: scc-collector
+        alias: scc
+        type: terraform
+        description: Module that installs an scc collector into a VPC VSI instance
+        tags:
+          - security
+        versions:
+          - platforms:
+              - vpc
+            dependencies:
+              - id: resource_group
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+                    version: ">= 2.1.0"
+              - id: vpc
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc
+                    version: ">= 1.0.0"
+              - id: vpcssh
+                refs:
+                  - source: github.com/cloud-native-toolkit/terraform-ibm-vpc-ssh
+                    version: ">= 1.0.0"
+            variables:
+              - name: resource_group_name
+                moduleRef:
+                  id: resource_group
+                  output: name
+                type: string
+                description: 'Name of Resource Group in which to provision the VSI. '
+              - name: vpc_id
+                moduleRef:
+                  id: vpc
+                  output: id
+                type: string
+                description: ID of VPC into which to provision the VSI.  A subnet will also be created.
+              - name: ssh_key_id
+                moduleRef:
+                  id: vpcssh
+                  output: id
+                type: string
+                description: ID of SSH Key already provisioned in the region.  This will be used to access the VSI.
+              - name: ssh_private_key
+                moduleRef:
+                  id: vpcssh
+                  output: private_key
+                type: string
+                description: The value of the private key that matches the ssh_key_id.
+              - name: region
+                scope: global
+                type: string
+                description: Region.  Must be same Region as the VPC
+              - name: zone
+                scope: ignore
+                type: string
+                description: Zone in which to provision the VSI.  Must be in the same Region as the VPC.
+                default: description = Zone in which to provision the VSI.  Must be in the same Region as the VPC.
+                optional: true
+              - name: name_prefix
+                scope: global
+                type: string
+                description: Prefix used to name all resources.
+                default: description = Prefix used to name all resources.
+                optional: true
+              - name: ibmcloud_api_key
+                scope: global
+                type: string
+                description: The IBM Cloud api key used to provision the IBM Cloud resources
+              - name: scc_registration_key
+                scope: global
+                type: string
+                description: The registration key generated for the SCC collector. The value can be created/retrieved here - https://cloud.ibm.com/security-compliance/settings?tab=collectors
+            version: v1.0.1
+            outputs:
+              - name: vsi_private_ip
+                description: output "vsi_private_ip" {   value = ibm_is_instance.vsi.primary_network_interface.0.primary_ipv4_address }
+              - name: vsi_floating_ip
+                description: output "vsi_floating_ip" {   value = ibm_is_floating_ip.vsi_floatingip.address }
+              - name: vsi_subnet
+                description: output "vsi_subnet" {   value = ibm_is_subnet.subnet_vsi.ipv4_cidr_block }
+              - name: vsi_security_group_id
+                description: output "vsi_security_group_id" {   value = ibm_is_security_group.vsi_sg.id }
+              - name: vsi_ssh_inboud_rule_id
+                description: output "vsi_ssh_inboud_rule_id" {   value = split(".", ibm_is_security_group_rule.rule-ssh-inbound.id)[1] }
+              - name: DISABLE_SSH
+                description: output "DISABLE_SSH" {   value = "nCommand to remove rule that allows inbound ssh:n ibmcloud is security-group-rule-delete ${ibm_is_security_group.vsi_sg.id} ${split(".", ibm_is_security_group_rule.rule-ssh-inbound.id)[1]}n" }
+          - platforms:
+              - vpc
+            dependencies: []
+            #    - id: cluster
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-ibm-container-platform
+            #          version: ">= 1.7.0"
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-ocp-cluster
+            #          version: ">= 2.0.0"
+            #    - id: namespace
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-namespace
+            #          version: ">= 2.1.0"
+            #    - id: dashboard
+            #      refs:
+            #        - source: github.com/cloud-native-toolkit/terraform-k8s-dashboard
+            #          version: ">= 1.6.0"
+            variables: [{name: resource_group_name, type: string, description: 'Name of Resource Group in which to provision the VSI. '}, {name: region, type: string, description: Region.  Must be same Region as the VPC}, {name: zone, type: string, description: Zone in which to provision the VSI.  Must be in the same Region as the VPC., default: description = Zone in which to provision the VSI.  Must be in the same Region as the VPC., optional: true}, {name: ibmcloud_api_key, type: string, description: The IBM Cloud api key used to provision the IBM Cloud resources}, {name: vpc_id, type: string, description: ID of VPC into which to provision the VSI.  A subnet will also be created.}, {name: name_prefix, type: string, description: Prefix used to name all resources., default: description = Prefix used to name all resources., optional: true}, {name: ssh_key_id, type: string, description: ID of SSH Key already provisioned in the region.  This will be used to access the VSI.}, {name: ssh_private_key, type: string, description: The value of the private key that matches the ssh_key_id.}, {name: scc_registration_key, type: string, description: 'The registration key generated for the SCC collector. The value can be created/retrieved here - https://cloud.ibm.com/security-compliance/settings?tab=collectors'}]
+            version: v1.0.0
+            outputs:
+              - name: vsi_private_ip
+                description: output "vsi_private_ip" {   value = ibm_is_instance.vsi.primary_network_interface.0.primary_ipv4_address }
+              - name: vsi_floating_ip
+                description: output "vsi_floating_ip" {   value = ibm_is_floating_ip.vsi_floatingip.address }
+              - name: vsi_subnet
+                description: output "vsi_subnet" {   value = ibm_is_subnet.subnet_vsi.ipv4_cidr_block }
+              - name: vsi_security_group_id
+                description: output "vsi_security_group_id" {   value = ibm_is_security_group.vsi_sg.id }
+              - name: vsi_ssh_inboud_rule_id
+                description: output "vsi_ssh_inboud_rule_id" {   value = split(".", ibm_is_security_group_rule.rule-ssh-inbound.id)[1] }
+              - name: DISABLE_SSH
+                description: output "DISABLE_SSH" {   value = "nCommand to remove rule that allows inbound ssh:n ibmcloud is security-group-rule-delete ${ibm_is_security_group.vsi_sg.id} ${split(".", ibm_is_security_group_rule.rule-ssh-inbound.id)[1]}n" }
+        provider: ibm


### PR DESCRIPTION
- Use the module names as an identifier in the BOM as an alternaive to the module source
- Support Terraform containing multiple instances of the same modules
- Support module providing an alias to distinguish multiple instances of the same module
- Allow selected modules to define which dependency instance to use via the defined alias, particularly in the event there are multiple instances of the same module. E.g. 3 different namespace instances defined, each with a different value; allow tool modules to select which namespace they use
- Allow selected modules to define values for their variables
- Adds example boms that utilize these features

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>