### PR TITLE
Adds validateBillOfMaterialModuleConfigYaml

### DIFF
--- a/src/errors/bill-of-material.error.ts
+++ b/src/errors/bill-of-material.error.ts
@@ -16,3 +16,19 @@ export class BillOfMaterialVariableParsingError extends Error {
     super('Error parsing BOM variable yaml: \n' + bomVariableYaml);
   }
 }
+
+export class BillOfMaterialModuleConfigError extends Error {
+  readonly unmatchedVariableNames: string[];
+  readonly unmatchedDependencyNames: string[];
+  readonly availableVariableNames: string[];
+  readonly availableDependencyNames: string[];
+
+  constructor({unmatchedVariableNames, unmatchedDependencyNames, availableVariableNames, availableDependencyNames}: {unmatchedVariableNames: string[], unmatchedDependencyNames: string[], availableVariableNames: string[], availableDependencyNames: string[]}) {
+    super('Variables and/or dependencies provided in config but not defined in module.');
+
+    this.availableDependencyNames = availableDependencyNames;
+    this.availableVariableNames = availableVariableNames;
+    this.unmatchedDependencyNames = unmatchedDependencyNames;
+    this.unmatchedVariableNames = unmatchedVariableNames;
+  }
+}

--- a/src/services/module-selector/module-selector.api.ts
+++ b/src/services/module-selector/module-selector.api.ts
@@ -5,4 +5,5 @@ import {SingleModuleVersion} from '../../models/module.model';
 export abstract class ModuleSelectorApi {
   abstract buildBillOfMaterial(fullCatalog: CatalogModel, input?: BillOfMaterialModel, filter?: {platform?: string, provider?: string}): Promise<BillOfMaterialModel>;
   abstract resolveBillOfMaterial(fullCatalog: CatalogModel, input: BillOfMaterialModel): Promise<SingleModuleVersion[]>;
+  abstract validateBillOfMaterialModuleConfigYaml(fullCatalog: CatalogModel, moduleRef: string, yaml: string): Promise<void>;
 }


### PR DESCRIPTION
- Parses BOM module config to check for errors
- Validates that the module exists in the catalog
- Validates that defined variables match values on the provided module
- Validates that defined dependencies match values on the provided module

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>