### PR TITLE
Updates workload-openshift ref architecture

### DIFF
--- a/ref-arch/140-mzr-workload-openshift.yaml
+++ b/ref-arch/140-mzr-workload-openshift.yaml
@@ -19,6 +19,9 @@ spec:
           value: false
         - name: name
           required: true
+        - name: name_prefix
+          alias: mgmt_name_prefix
+          scope: global
     - name: ibm-resource-group
       variables:
         - name: resource_group_name
@@ -155,6 +158,20 @@ spec:
     - name: workload_resource_group_provision
     - name: cs_resource_group_name
     - name: cs_name_prefix
+    - name: mgmt_name_prefix
+    - name: hpcs_name
+    - name: workload_ssh_vpn_public_key
+      value: ""
+    - name: workload_ssh_vpn_private_key
+      value: ""
+    - name: workload_ssh_bastion_public_key
+      value: ""
+    - name: workload_ssh_bastion_private_key
+      value: ""
+    - name: workload_ssh_scc_public_key
+      value: ""
+    - name: workload_ssh_scc_private_key
+      value: ""
     - name: workload_ssh_vpn_public_key_file
     - name: workload_ssh_vpn_private_key_file
     - name: workload_ssh_bastion_public_key_file

--- a/src/services/bill-of-material-builder/bill-of-material-builder.ts
+++ b/src/services/bill-of-material-builder/bill-of-material-builder.ts
@@ -69,8 +69,10 @@ function parseModuleConfigYaml(moduleConfigYaml: string): Omit<BillOfMaterialMod
 export async function loadReferenceBom(name: string, newName?: string): Promise<BillOfMaterialModel> {
   const boms: BillOfMaterialModel[] = await loadReferenceBoms();
 
+  const nameMatcher = new RegExp(name + '.*', 'ig');
+
   return arrayOf(boms)
-    .filter(bom => bom.metadata?.name === name)
+    .filter(bom => nameMatcher.test(bom.metadata?.name))
     .first()
     .map(bom => {
       return Object.assign(


### PR DESCRIPTION
- Fixes ssh key references
- Sets alias for name_prefix variable in management-vpc module
- Adds logic to use shorthand for ref arch names

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>