### PR TITLE
Updates to reference architectures for rc3

### DIFF
--- a/ref-arch/000-account-setup.yaml
+++ b/ref-arch/000-account-setup.yaml
@@ -1,0 +1,100 @@
+apiVersion: cloud.ibm.com/v1alpha1
+kind: BillOfMaterial
+metadata:
+  name: 000-account-setup
+spec:
+  modules:
+    - name: ibm-resource-group
+      variables:
+        - name: resource_group_name
+          alias: hpcs_resource_group_name
+          scope: global
+        - name: provision
+          alias: hpcs_resource_group_provision
+          scope: global
+          value: false
+    - name: ibm-activity-tracker
+      alias: at-us-east
+      variables:
+        - name: resource_location
+          value: "us-east"
+          scope: module
+        - name: provision
+          value: true
+    - name: ibm-activity-tracker
+      alias: at-us-south
+      variables:
+        - name: resource_location
+          value: "us-south"
+          scope: module
+        - name: provision
+          value: true
+    - name: ibm-activity-tracker
+      alias: at-eu-de
+      variables:
+        - name: resource_location
+          value: "eu-de"
+          scope: module
+        - name: provision
+          value: true
+    - name: ibm-activity-tracker
+      alias: at-eu-gb
+      variables:
+        - name: resource_location
+          value: "eu-gb"
+          scope: module
+        - name: provision
+          value: true
+    - name: ibm-onboard-fs-account
+      variables:
+        - name: action
+          value: enable
+        - name: mfa
+          value: TOTP4ALL
+        - name: restrict_create_service_id
+          value: RESTRICTED
+        - name: restrict_create_platform_apikey
+          value: RESTRICTED
+    - name: hpcs
+      variables:
+        - name: provision
+          value: false
+        - name: region
+          alias: hpcs_region
+        - name: name_prefix
+          alias: hpcs_name_prefix
+          scope: global
+        - name: name
+          required: true
+    - name: ibm-iam-service-authorization
+      alias: vsi-encrypt-auth
+      variables:
+        - name: source_service_name
+          value: server-protect
+        - name: target_service_name
+          value: hs-crypto
+        - name: roles
+          value:
+            - Reader
+      dependencies:
+        - name: target_resource_group
+          ref: resource_group
+    - name: ibm-iam-service-authorization
+      alias: cos-encrypt-auth
+      variables:
+        - name: source_service_name
+          value: cloud-object-storage
+        - name: target_service_name
+          value: hs-crypto
+        - name: roles
+          value:
+            - Reader
+      dependencies:
+        - name: target_resource_group
+          ref: resource_group
+  variables:
+    - name: cs_resource_group_provision
+    - name: name_prefix
+      alias: cs_name_prefix
+    - name: region
+    - name: cs_resource_group_name

--- a/ref-arch/100-shared-services.yaml
+++ b/ref-arch/100-shared-services.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
-  name: 100-common-services
+  name: 100-shared-services
 spec:
   modules:
     - name: ibm-resource-group
@@ -15,28 +15,8 @@ spec:
     - name: ibm-access-group
     - name: key-protect
     - name: ibm-object-storage
-    - name: ibm-activity-tracker
     - name: sysdig
     - name: logdna
-    - name: ibm-resource-group
-      alias: hpcs_resource_group
-      variables:
-        - name: provision
-          value: false
-    - name: hpcs
-      variables:
-        - name: provision
-          value: false
-        - name: region
-          alias: hpcs_region
-        - name: name_prefix
-          alias: hpcs_name_prefix
-          scope: global
-        - name: name
-          required: true
-      dependencies:
-        - name: resource_group
-          ref: hpcs_resource_group
     - name: ibm-iam-service-authorization
       alias: flow-log-auth
       variables:
@@ -59,16 +39,28 @@ spec:
         - name: target_service_name
           value: hs-crypto
         - name: roles
-          value: ["Reader"]
+          value:
+            - Reader
+      dependencies:
+        - name: source_resource_group
+          ref: resource_group
+        - name: target_resource_group
+          ref: hpcs_resource_group
     - name: ibm-iam-service-authorization
-      alias: cos-encrypt-auth
+      alias: kube-encrypt-auth
       variables:
         - name: source_service_name
-          value: cloud-object-storage
+          value: containers-kubernetes
         - name: target_service_name
           value: hs-crypto
         - name: roles
-          value: ["Reader"]
+          value:
+            - Reader
+      dependencies:
+        - name: source_resource_group
+          ref: resource_group
+        - name: target_resource_group
+          ref: hpcs_resource_group
   variables:
     - name: cs_resource_group_provision
     - name: name_prefix

--- a/ref-arch/110-mzr-management.yaml
+++ b/ref-arch/110-mzr-management.yaml
@@ -19,6 +19,7 @@ spec:
         - name: name_prefix
           alias: hpcs_name_prefix
           scope: global
+          value: ""
       dependencies:
         - name: resource_group
           ref: hpcs_resource_group
@@ -49,17 +50,20 @@ spec:
           ref: flow_log_bucket
     - name: ibm-vpc-gateways
     - name: ibm-vpc-subnets
-      alias: workload-subnets
+      alias: worker-subnets
       variables:
         - name: _count
           value: 3
         - name: label
-          value: workload
+          value: worker
         - name: ipv4_cidr_blocks
           value:
             - 10.10.10.0/24
             - 10.20.10.0/24
             - 10.30.10.0/24
+      dependencies:
+        - name: gateways
+          ref: ibm-vpc-gateways
     - name: ibm-vpc-subnets
       alias: vpe-subnets
       variables:
@@ -82,18 +86,6 @@ spec:
         - name: ipv4_cidr_blocks
           value:
             - 10.10.30.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
     - name: ibm-vpc-subnets
       alias: bastion-subnets
       variables:
@@ -112,11 +104,12 @@ spec:
       variables:
         - name: label
           value: vpn
+    - name: ibm-vpc-vpn-gateway
+      dependencies:
+        - name: subnets
+          ref: vpn-subnets
     - name: vsi-vpn
       variables:
-        - name: image_name
-          scope: module
-          value: ibm-centos-7-9-minimal-amd64-3
         - name: kms_enabled
           value: true
       dependencies:
@@ -163,11 +156,31 @@ spec:
       dependencies:
         - name: kms
           ref: hpcs
+    - name: ibm-activity-tracker
+      variables:
+        - name: provision
+          value: false
+      dependencies:
+        - name: resource_group
+          ref: hpcs_resource_group
+    - name: sysdig
+      variables:
+        - name: provision
+          value: false
+        - name: name_prefix
+          alias: cs_name_prefix
+          scope: global
+      dependencies:
+        - name: resource_group
+          ref: cs_resource_group
     - name: ibm-object-storage-bucket
       alias: flow_log_bucket
       variables:
         - name: label
           value: flow-logs
+        - name: allowed_ip
+          value:
+            - 0.0.0.0/0
     - name: ibm-vpe-gateway
       alias: vpe-cos
       dependencies:
@@ -175,42 +188,6 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-vpc-subnets
-      alias: scc-subnets
-      variables:
-        - name: _count
-          value: 1
-        - name: label
-          value: scc
-        - name: ipv4_cidr_blocks
-          value:
-            - 10.1.1.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-    - name: ibm-vpc-ssh
-      alias: mgmt_ssh_scc
-      variables:
-        - name: label
-          value: scc
-    - name: scc-collector
-      variables:
-        - name: kms_enabled
-          value: true
-      dependencies:
-        - name: vpcssh
-          ref: mgmt_ssh_scc
-        - name: subnets
-          ref: scc-subnets
     - name: ibm-iam-service-authorization
       alias: vsi-encrypt-auth
       variables:
@@ -220,6 +197,21 @@ spec:
           value: hs-crypto
         - name: roles
           value: ["Reader"]
+      dependencies:
+        - name: source_resource_group
+          ref: resource_group
+        - name: target_resource_group
+          ref: hpcs_resource_group
+    - name: ibm-iam-service-authorization
+      alias: kube-encrypt-auth
+      variables:
+        - name: source_service_name
+          value: containers-kubernetes
+        - name: target_service_name
+          value: hs-crypto
+        - name: roles
+          value:
+            - Reader
       dependencies:
         - name: source_resource_group
           ref: resource_group
@@ -243,13 +235,7 @@ spec:
       value: ""
     - name: mgmt_ssh_bastion_private_key
       value: ""
-    - name: mgmt_ssh_scc_public_key
-      value: ""
-    - name: mgmt_ssh_scc_private_key
-      value: ""
     - name: mgmt_ssh_vpn_public_key_file
     - name: mgmt_ssh_vpn_private_key_file
     - name: mgmt_ssh_bastion_public_key_file
     - name: mgmt_ssh_bastion_private_key_file
-    - name: mgmt_ssh_scc_public_key_file
-    - name: mgmt_ssh_scc_private_key_file

--- a/ref-arch/120-mzr-management-openshift.yaml
+++ b/ref-arch/120-mzr-management-openshift.yaml
@@ -19,6 +19,7 @@ spec:
         - name: name_prefix
           alias: hpcs_name_prefix
           scope: global
+          value: ""
       dependencies:
         - name: resource_group
           ref: hpcs_resource_group
@@ -49,28 +50,30 @@ spec:
           ref: flow_log_bucket
     - name: ibm-vpc-gateways
     - name: ibm-vpc-subnets
-      alias: workload-subnets
+      alias: worker-subnets
       variables:
         - name: _count
           value: 3
         - name: label
-          value: workload
+          value: worker
         - name: ipv4_cidr_blocks
           value:
             - 10.10.10.0/24
             - 10.20.10.0/24
             - 10.30.10.0/24
+      dependencies:
+        - name: gateways
+          ref: ibm-vpc-gateways
     - name: ibm-ocp-vpc
+      alias: cluster
       variables:
         - name: disable_public_endpoint
           value: true
         - name: kms_enabled
           value: true
-        - name: authorize_kms
-          value: false
       dependencies:
         - name: subnets
-          ref: workload-subnets
+          ref: worker-subnets
         - name: kms_key
           ref: kms_key
     - name: ibm-vpc-subnets
@@ -95,18 +98,6 @@ spec:
         - name: ipv4_cidr_blocks
           value:
             - 10.10.30.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
     - name: ibm-vpc-subnets
       alias: bastion-subnets
       variables:
@@ -125,11 +116,12 @@ spec:
       variables:
         - name: label
           value: vpn
+    - name: ibm-vpc-vpn-gateway
+      dependencies:
+        - name: subnets
+          ref: vpn-subnets
     - name: vsi-vpn
       variables:
-        - name: image_name
-          scope: module
-          value: ibm-centos-7-9-minimal-amd64-3
         - name: kms_enabled
           value: true
       dependencies:
@@ -176,11 +168,31 @@ spec:
       dependencies:
         - name: kms
           ref: hpcs
+    - name: ibm-activity-tracker
+      variables:
+        - name: provision
+          value: false
+      dependencies:
+        - name: resource_group
+          ref: hpcs_resource_group
+    - name: sysdig
+      variables:
+        - name: provision
+          value: false
+        - name: name_prefix
+          alias: cs_name_prefix
+          scope: global
+      dependencies:
+        - name: resource_group
+          ref: cs_resource_group
     - name: ibm-object-storage-bucket
       alias: flow_log_bucket
       variables:
         - name: label
           value: flow-logs
+        - name: allowed_ip
+          value:
+            - 0.0.0.0/0
     - name: ibm-vpe-gateway
       alias: vpe-cos
       dependencies:
@@ -188,42 +200,8 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-vpc-subnets
-      alias: scc-subnets
-      variables:
-        - name: _count
-          value: 1
-        - name: label
-          value: scc
-        - name: ipv4_cidr_blocks
-          value:
-            - 10.1.1.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-    - name: ibm-vpc-ssh
-      alias: mgmt_ssh_scc
-      variables:
-        - name: label
-          value: scc
-    - name: scc-collector
-      variables:
-        - name: kms_enabled
-          value: true
-      dependencies:
-        - name: vpcssh
-          ref: mgmt_ssh_scc
-        - name: subnets
-          ref: scc-subnets
+        - name: sync
+          ref: cluster
     - name: ibm-iam-service-authorization
       alias: vsi-encrypt-auth
       variables:
@@ -233,6 +211,21 @@ spec:
           value: hs-crypto
         - name: roles
           value: ["Reader"]
+      dependencies:
+        - name: source_resource_group
+          ref: resource_group
+        - name: target_resource_group
+          ref: hpcs_resource_group
+    - name: ibm-iam-service-authorization
+      alias: kube-encrypt-auth
+      variables:
+        - name: source_service_name
+          value: containers-kubernetes
+        - name: target_service_name
+          value: hs-crypto
+        - name: roles
+          value:
+            - Reader
       dependencies:
         - name: source_resource_group
           ref: resource_group
@@ -257,13 +250,7 @@ spec:
       value: ""
     - name: mgmt_ssh_bastion_private_key
       value: ""
-    - name: mgmt_ssh_scc_public_key
-      value: ""
-    - name: mgmt_ssh_scc_private_key
-      value: ""
     - name: mgmt_ssh_vpn_public_key_file
     - name: mgmt_ssh_vpn_private_key_file
     - name: mgmt_ssh_bastion_public_key_file
     - name: mgmt_ssh_bastion_private_key_file
-    - name: mgmt_ssh_scc_public_key_file
-    - name: mgmt_ssh_scc_private_key_file

--- a/ref-arch/130-mzr-workload.yaml
+++ b/ref-arch/130-mzr-workload.yaml
@@ -19,6 +19,7 @@ spec:
         - name: name_prefix
           alias: hpcs_name_prefix
           scope: global
+          value: ""
       dependencies:
         - name: resource_group
           ref: hpcs_resource_group
@@ -67,17 +68,20 @@ spec:
           ref: flow_log_bucket
     - name: ibm-vpc-gateways
     - name: ibm-vpc-subnets
-      alias: workload-subnets
+      alias: worker-subnets
       variables:
         - name: _count
           value: 3
         - name: label
-          value: workload
+          value: worker
         - name: ipv4_cidr_blocks
           value:
             - 10.40.10.0/24
             - 10.50.10.0/24
             - 10.60.10.0/24
+      dependencies:
+        - name: gateways
+          ref: ibm-vpc-gateways
     - name: ibm-vpc-subnets
       alias: vpe-subnets
       variables:
@@ -142,11 +146,31 @@ spec:
       dependencies:
         - name: kms
           ref: hpcs
+    - name: ibm-activity-tracker
+      variables:
+        - name: provision
+          value: false
+      dependencies:
+        - name: resource_group
+          ref: hpcs_resource_group
+    - name: sysdig
+      variables:
+        - name: provision
+          value: false
+        - name: name_prefix
+          alias: cs_name_prefix
+          scope: global
+      dependencies:
+        - name: resource_group
+          ref: cs_resource_group
     - name: ibm-object-storage-bucket
       alias: flow_log_bucket
       variables:
         - name: label
           value: flow-logs
+        - name: allowed_ip
+          value:
+            - 0.0.0.0/0
     - name: ibm-vpe-gateway
       alias: vpe-cos
       dependencies:
@@ -154,42 +178,6 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-vpc-subnets
-      alias: scc-subnets
-      variables:
-        - name: _count
-          value: 1
-        - name: label
-          value: scc
-        - name: ipv4_cidr_blocks
-          value:
-            - 10.2.1.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-    - name: ibm-vpc-ssh
-      alias: workload_ssh_scc
-      variables:
-        - name: label
-          value: scc
-    - name: scc-collector
-      variables:
-        - name: kms_enabled
-          value: true
-      dependencies:
-        - name: vpcssh
-          ref: workload_ssh_scc
-        - name: subnets
-          ref: scc-subnets
     - name: ibm-iam-service-authorization
       alias: vsi-encrypt-auth
       variables:
@@ -226,13 +214,7 @@ spec:
       value: ""
     - name: workload_ssh_bastion_private_key
       value: ""
-    - name: workload_ssh_scc_public_key
-      value: ""
-    - name: workload_ssh_scc_private_key
-      value: ""
     - name: workload_ssh_vpn_public_key_file
     - name: workload_ssh_vpn_private_key_file
     - name: workload_ssh_bastion_public_key_file
     - name: workload_ssh_bastion_private_key_file
-    - name: workload_ssh_scc_public_key_file
-    - name: workload_ssh_scc_private_key_file

--- a/ref-arch/140-mzr-workload-openshift.yaml
+++ b/ref-arch/140-mzr-workload-openshift.yaml
@@ -19,6 +19,7 @@ spec:
         - name: name_prefix
           alias: hpcs_name_prefix
           scope: global
+          value: ""
       dependencies:
         - name: resource_group
           ref: hpcs_resource_group
@@ -67,28 +68,30 @@ spec:
           ref: flow_log_bucket
     - name: ibm-vpc-gateways
     - name: ibm-vpc-subnets
-      alias: workload-subnets
+      alias: worker-subnets
       variables:
         - name: _count
           value: 3
         - name: label
-          value: workload
+          value: worker
         - name: ipv4_cidr_blocks
           value:
             - 10.40.10.0/24
             - 10.50.10.0/24
             - 10.60.10.0/24
+      dependencies:
+        - name: gateways
+          ref: ibm-vpc-gateways
     - name: ibm-ocp-vpc
+      alias: cluster
       variables:
         - name: disable_public_endpoint
           value: true
         - name: kms_enabled
           value: true
-        - name: authorize_kms
-          value: false
       dependencies:
         - name: subnets
-          ref: workload-subnets
+          ref: worker-subnets
         - name: kms_key
           ref: kms_key
     - name: ibm-vpc-subnets
@@ -155,11 +158,31 @@ spec:
       dependencies:
         - name: kms
           ref: hpcs
+    - name: ibm-activity-tracker
+      variables:
+        - name: provision
+          value: false
+      dependencies:
+        - name: resource_group
+          ref: hpcs_resource_group
+    - name: sysdig
+      variables:
+        - name: provision
+          value: false
+        - name: name_prefix
+          alias: cs_name_prefix
+          scope: global
+      dependencies:
+        - name: resource_group
+          ref: cs_resource_group
     - name: ibm-object-storage-bucket
       alias: flow_log_bucket
       variables:
         - name: label
           value: flow-logs
+        - name: allowed_ip
+          value:
+            - 0.0.0.0/0
     - name: ibm-vpe-gateway
       alias: vpe-cos
       dependencies:
@@ -167,42 +190,8 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-vpc-subnets
-      alias: scc-subnets
-      variables:
-        - name: _count
-          value: 1
-        - name: label
-          value: scc
-        - name: ipv4_cidr_blocks
-          value:
-            - 10.2.1.0/24
-        - name: acl_rules
-          value:
-            - name: ingress-all
-              action: allow
-              direction: inbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-            - name: egress-all
-              action: allow
-              direction: outbound
-              source: "0.0.0.0/0"
-              destination: "0.0.0.0/0"
-    - name: ibm-vpc-ssh
-      alias: workload_ssh_scc
-      variables:
-        - name: label
-          value: scc
-    - name: scc-collector
-      variables:
-        - name: kms_enabled
-          value: true
-      dependencies:
-        - name: vpcssh
-          ref: workload_ssh_scc
-        - name: subnets
-          ref: scc-subnets
+        - name: sync
+          ref: cluster
     - name: ibm-iam-service-authorization
       alias: vsi-encrypt-auth
       variables:
@@ -239,13 +228,7 @@ spec:
       value: ""
     - name: workload_ssh_bastion_private_key
       value: ""
-    - name: workload_ssh_scc_public_key
-      value: ""
-    - name: workload_ssh_scc_private_key
-      value: ""
     - name: workload_ssh_vpn_public_key_file
     - name: workload_ssh_vpn_private_key_file
     - name: workload_ssh_bastion_public_key_file
     - name: workload_ssh_bastion_private_key_file
-    - name: workload_ssh_scc_public_key_file
-    - name: workload_ssh_scc_private_key_file

--- a/ref-arch/150-openshift.yaml
+++ b/ref-arch/150-openshift.yaml
@@ -48,8 +48,6 @@ spec:
           value: true
         - name: kms_enabled
           value: true
-        - name: authorize_kms
-          value: false
       dependencies:
         - name: subnets
           ref: workload-subnets

--- a/ref-arch/165-openshift-workload.yaml
+++ b/ref-arch/165-openshift-workload.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
-  name: 160-openshift-dev-tools
+  name: 165-openshift-workload
 spec:
   modules:
     - name: ibm-resource-group
@@ -9,7 +9,7 @@ spec:
         - name: provision
           value: false
         - name: resource_group_name
-          alias: mgmt_resource_group_name
+          alias: workload_resource_group_name
           scope: global
     - name: ibm-ocp-vpc
       dependencies:
@@ -73,15 +73,10 @@ spec:
     - name: cluster-config
       variables:
         - name: banner_text
-          value: Management
+          value: Workload
+        - name: banner_background_color
+          value: red
     - name: argocd
-    - name: dashboard
-    - name: pactbroker
-    - name: artifactory
-    - name: sonarqube
-    - name: tekton
-    - name: tekton-resources
-    - name: source-control
   variables:
     - name: resource_group_name
     - name: region
@@ -90,5 +85,5 @@ spec:
     - name: registry_namespace
       required: true
     - name: name_prefix
-      alias: mgmt_name_prefix
       required: true
+      alias: workload_name_prefix

--- a/ref-arch/170-openshift-argocd.yaml
+++ b/ref-arch/170-openshift-argocd.yaml
@@ -21,6 +21,9 @@ spec:
       alias: config
       variables:
         - name: banner_text
+          value: Workload
+        - name: banner_background_color
+          value: red
     - name: argocd
   variables:
     - name: config_banner_text

--- a/src/services/iascable.impl.ts
+++ b/src/services/iascable.impl.ts
@@ -78,7 +78,7 @@ const findModule = (m: string | BillOfMaterialModule, modules: SingleModuleVersi
       return module.alias === moduleVersion.alias || module.name === moduleVersion.name || module.id === moduleVersion.id;
     })
     .first()
-    .get();
+    .orElseThrow(new Error('Unable to find module: ' + module.name));
 }
 
 const mergeBillOfMaterialModule = (module: string | BillOfMaterialModule, moduleVersion: SingleModuleVersion): BillOfMaterialModule => {


### PR DESCRIPTION
- Adds 000 ref arch and removes activity-tracker from 100
- Adds default values for onboard-fs-account module
- Adds gateways to subnets and sets allowed_ip for bucket
- Updates default catalog to modules.cloudnativetoolkit.dev
- Removes acl_rules from BOM (should not be needed)
- Fixes resource_locations for activity tracker instances
- Updates allowed_ip value and hpcs_name_prefix
- Adds vpc-gateway to worker subnets
- Removes (incorrect) image_name from vpn server
- Removes public gateway from vpn-subnets
- Removes authorize-kms from BOMs

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>