### PR TITLE
Update 170-openshift-argocd.yaml

### DIFF
--- a/ref-arch/170-openshift-argocd.yaml
+++ b/ref-arch/170-openshift-argocd.yaml
@@ -8,9 +8,9 @@ spec:
       variables:
         - name: server_url
           required: true
-        - name: user
+        - name: login_user
           value: apikey
-        - name: password
+        - name: login_password
           alias: ibmcloud_api_key
           scope: global
     - name: namespace


### PR DESCRIPTION
Variable names `user` and `password` of module `ocp-login` in `170-openshift-argocd.yaml` appear to be wrong and needed to be replaced by `login_user` and `login_password`, see issue #65