### PR TITLE
 Updates reference architectures to allow flexibility of deployed size

### DIFF
--- a/examples/baseline-ocp.yaml
+++ b/examples/baseline-ocp.yaml
@@ -1,0 +1,27 @@
+apiVersion: cloud.ibm.com/v1alpha1
+kind: BillOfMaterial
+metadata:
+  name: baseline-ocp
+spec:
+  modules:
+    - name: ibm-resource-group
+    - name: ibm-vpc
+    - name: ibm-vpc-gateways
+    - name: ibm-vpc-subnets
+      alias: cluster-subnets
+      variables:
+        - name: subnet_count
+          value: 1
+        - name: subnet_label
+          value: cluster
+    - name: ibm-ocp-vpc
+      dependencies:
+        - name: subnets
+          ref: cluster-subnets
+    - name: openshift-cicd
+  variables:
+    - name: resource_group_name
+    - name: region
+    - name: ibmcloud_api_key
+    - name: name_prefix
+      required: true

--- a/ref-arch/000-account-setup.yaml
+++ b/ref-arch/000-account-setup.yaml
@@ -2,15 +2,21 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 000-account-setup
+  labels:
+    platform: ibm
+    code: 000
+  annotations:
+    displayName: Account setup
+    description: Sets up an IBM Cloud account with required Financial Services reference architecture settings
 spec:
   modules:
     - name: ibm-resource-group
       variables:
         - name: resource_group_name
-          alias: hpcs_resource_group_name
+          alias: at_resource_group_name
           scope: global
         - name: provision
-          alias: hpcs_resource_group_provision
+          alias: at_resource_group_provision
           scope: global
           value: false
     - name: ibm-activity-tracker
@@ -55,46 +61,9 @@ spec:
           value: RESTRICTED
         - name: restrict_create_platform_apikey
           value: RESTRICTED
-    - name: hpcs
-      variables:
-        - name: provision
-          value: false
-        - name: region
-          alias: hpcs_region
-        - name: name_prefix
-          alias: hpcs_name_prefix
-          scope: global
-        - name: name
-          required: true
-    - name: ibm-iam-service-authorization
-      alias: vsi-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: server-protect
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value:
-            - Reader
-      dependencies:
-        - name: target_resource_group
-          ref: resource_group
-    - name: ibm-iam-service-authorization
-      alias: cos-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: cloud-object-storage
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value:
-            - Reader
-      dependencies:
-        - name: target_resource_group
-          ref: resource_group
   variables:
-    - name: cs_resource_group_provision
+    - name: at_resource_group_provision
+    - name: at_resource_group_name
     - name: name_prefix
-      alias: cs_name_prefix
+      alias: common_name_prefix
     - name: region
-    - name: cs_resource_group_name

--- a/ref-arch/100-shared-services.yaml
+++ b/ref-arch/100-shared-services.yaml
@@ -2,6 +2,12 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 100-shared-services
+  labels:
+    platform: ibm
+    code: 100
+  annotations:
+    displayName: Shared services
+    description: Managed services that are shared across the management and workload networks
 spec:
   modules:
     - name: ibm-resource-group
@@ -12,11 +18,62 @@ spec:
         - name: provision
           alias: cs_resource_group_provision
           scope: global
+    - name: ibm-resource-group
+      alias: kms_resource_group
+      variables:
+        - name: resource_group_name
+          alias: kms_resource_group_name
+          scope: global
+        - name: provision
+          alias: kms_resource_group_provision
+          scope: global
+          value: false
+      dependencies:
+        - name: sync
+          ref: resource_group
+    - name: ibm-kms
+      alias: kms
+      variables:
+        - name: region
+          alias: kms_region
+        - name: name_prefix
+          alias: kms_name_prefix
+          scope: global
+        - name: name
+          required: true
+      dependencies:
+        - name: resource_group
+          ref: kms_resource_group
     - name: ibm-access-group
-    - name: key-protect
     - name: ibm-object-storage
     - name: sysdig
     - name: logdna
+    - name: ibm-iam-service-authorization
+      alias: vsi-encrypt-auth
+      variables:
+        - name: source_service_name
+          value: server-protect
+        - name: roles
+          value:
+            - Reader
+      dependencies:
+        - name: target_resource_group
+          ref: kms_resource_group
+        - name: target_resource
+          ref: kms
+    - name: ibm-iam-service-authorization
+      alias: cos-encrypt-auth
+      variables:
+        - name: roles
+          value:
+            - Reader
+      dependencies:
+        - name: target_resource_group
+          ref: kms_resource_group
+        - name: target_resource
+          ref: kms
+        - name: source_resource
+          ref: cos
     - name: ibm-iam-service-authorization
       alias: flow-log-auth
       variables:
@@ -24,20 +81,19 @@ spec:
           value: is
         - name: source_resource_type
           value: flow-log-collector
-        - name: target_service_name
-          value: cloud-object-storage
         - name: roles
-          value: ["Writer"]
+          value:
+            - Writer
       dependencies:
         - name: target_resource_group
           ref: resource_group
+        - name: target_resource
+          ref: cos
     - name: ibm-iam-service-authorization
       alias: vsi-encrypt-auth
       variables:
         - name: source_service_name
           value: server-protect
-        - name: target_service_name
-          value: hs-crypto
         - name: roles
           value:
             - Reader
@@ -45,14 +101,14 @@ spec:
         - name: source_resource_group
           ref: resource_group
         - name: target_resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
+        - name: target_resource
+          ref: kms
     - name: ibm-iam-service-authorization
       alias: kube-encrypt-auth
       variables:
         - name: source_service_name
           value: containers-kubernetes
-        - name: target_service_name
-          value: hs-crypto
         - name: roles
           value:
             - Reader
@@ -60,10 +116,14 @@ spec:
         - name: source_resource_group
           ref: resource_group
         - name: target_resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
+        - name: target_resource
+          ref: kms
   variables:
+    - name: kms_resource_group_provision
     - name: cs_resource_group_provision
     - name: name_prefix
       alias: cs_name_prefix
     - name: region
     - name: cs_resource_group_name
+    - name: kms_service

--- a/ref-arch/110-mzr-management.yaml
+++ b/ref-arch/110-mzr-management.yaml
@@ -2,27 +2,38 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 110-mzr-management
+  labels:
+    platform: ibm
+    code: 110
+  annotations:
+    displayName: MZR Management VPC
+    description: Multi-Zone Management VPC with VPN and Bastion servers
 spec:
   modules:
     - name: ibm-resource-group
-      alias: hpcs_resource_group
+      alias: kms_resource_group
       variables:
         - name: provision
           value: false
-    - name: hpcs
-      alias: hpcs
+    - name: ibm-resource-group
+      alias: at_resource_group
+      variables:
+        - name: provision
+          value: false
+    - name: ibm-kms
+      alias: kms
       variables:
         - name: provision
           value: false
         - name: region
-          alias: hpcs_region
+          alias: kms_region
         - name: name_prefix
-          alias: hpcs_name_prefix
+          alias: kms_name_prefix
           scope: global
           value: ""
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
     - name: ibm-resource-group
       variables:
         - name: resource_group_name
@@ -155,14 +166,14 @@ spec:
           value: true
       dependencies:
         - name: kms
-          ref: hpcs
+          ref: kms
     - name: ibm-activity-tracker
       variables:
         - name: provision
           value: false
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: at_resource_group
     - name: sysdig
       variables:
         - name: provision
@@ -188,35 +199,6 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-iam-service-authorization
-      alias: vsi-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: server-protect
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value: ["Reader"]
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
-    - name: ibm-iam-service-authorization
-      alias: kube-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: containers-kubernetes
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value:
-            - Reader
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
   variables:
     - name: mgmt_resource_group_name
     - name: mgmt_resource_group_provision
@@ -239,3 +221,4 @@ spec:
     - name: mgmt_ssh_vpn_private_key_file
     - name: mgmt_ssh_bastion_public_key_file
     - name: mgmt_ssh_bastion_private_key_file
+    - name: kms_service

--- a/ref-arch/120-mzr-management-openshift.yaml
+++ b/ref-arch/120-mzr-management-openshift.yaml
@@ -2,27 +2,38 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 120-mzr-management-openshift
+  labels:
+    platform: ibm
+    code: 120
+  annotations:
+    displayName: MZR Management VPC OpenShift
+    description: Multi-Zone Management VPC with VPN, Bastion, and Red Hat OpenShift servers
 spec:
   modules:
     - name: ibm-resource-group
-      alias: hpcs_resource_group
+      alias: kms_resource_group
       variables:
         - name: provision
           value: false
-    - name: hpcs
-      alias: hpcs
+    - name: ibm-resource-group
+      alias: at_resource_group
+      variables:
+        - name: provision
+          value: false
+    - name: ibm-kms
+      alias: kms
       variables:
         - name: provision
           value: false
         - name: region
-          alias: hpcs_region
+          alias: kms_region
         - name: name_prefix
-          alias: hpcs_name_prefix
+          alias: kms_name_prefix
           scope: global
           value: ""
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
     - name: ibm-resource-group
       variables:
         - name: resource_group_name
@@ -53,6 +64,8 @@ spec:
       alias: worker-subnets
       variables:
         - name: _count
+          alias: mgmt_worker_subnet_count
+          scope: global
           value: 3
         - name: label
           value: worker
@@ -71,6 +84,8 @@ spec:
           value: true
         - name: kms_enabled
           value: true
+        - name: worker_count
+          alias: mgmt_worker_count
       dependencies:
         - name: subnets
           ref: worker-subnets
@@ -167,14 +182,14 @@ spec:
           value: true
       dependencies:
         - name: kms
-          ref: hpcs
+          ref: kms
     - name: ibm-activity-tracker
       variables:
         - name: provision
           value: false
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: at_resource_group
     - name: sysdig
       variables:
         - name: provision
@@ -202,35 +217,6 @@ spec:
           ref: vpe-subnets
         - name: sync
           ref: cluster
-    - name: ibm-iam-service-authorization
-      alias: vsi-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: server-protect
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value: ["Reader"]
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
-    - name: ibm-iam-service-authorization
-      alias: kube-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: containers-kubernetes
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value:
-            - Reader
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
   variables:
     - name: mgmt_resource_group_name
     - name: mgmt_resource_group_provision
@@ -254,3 +240,4 @@ spec:
     - name: mgmt_ssh_vpn_private_key_file
     - name: mgmt_ssh_bastion_public_key_file
     - name: mgmt_ssh_bastion_private_key_file
+    - name: kms_service

--- a/ref-arch/130-mzr-workload.yaml
+++ b/ref-arch/130-mzr-workload.yaml
@@ -2,27 +2,38 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 130-mzr-workload
+  labels:
+    platform: ibm
+    code: 130
+  annotations:
+    displayName: MZR Workload VPC
+    description: Multi-Zone Workload VPC with VPC Transit Gateway to Management VPC
 spec:
   modules:
     - name: ibm-resource-group
-      alias: hpcs_resource_group
+      alias: kms_resource_group
       variables:
         - name: provision
           value: false
-    - name: hpcs
-      alias: hpcs
+    - name: ibm-resource-group
+      alias: at_resource_group
+      variables:
+        - name: provision
+          value: false
+    - name: ibm-kms
+      alias: kms
       variables:
         - name: provision
           value: false
         - name: region
-          alias: hpcs_region
+          alias: kms_region
         - name: name_prefix
-          alias: hpcs_name_prefix
+          alias: kms_name_prefix
           scope: global
           value: ""
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
     - name: ibm-resource-group
       alias: mgmt_resource_group
       variables:
@@ -145,14 +156,14 @@ spec:
           value: true
       dependencies:
         - name: kms
-          ref: hpcs
+          ref: kms
     - name: ibm-activity-tracker
       variables:
         - name: provision
           value: false
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: at_resource_group
     - name: sysdig
       variables:
         - name: provision
@@ -178,20 +189,6 @@ spec:
           ref: cos
         - name: subnets
           ref: vpe-subnets
-    - name: ibm-iam-service-authorization
-      alias: vsi-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: server-protect
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value: ["Reader"]
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
     - name: ibm-transit-gateway
   variables:
     - name: workload_resource_group_name
@@ -218,3 +215,4 @@ spec:
     - name: workload_ssh_vpn_private_key_file
     - name: workload_ssh_bastion_public_key_file
     - name: workload_ssh_bastion_private_key_file
+    - name: kms_service

--- a/ref-arch/140-mzr-workload-openshift.yaml
+++ b/ref-arch/140-mzr-workload-openshift.yaml
@@ -2,27 +2,38 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: 140-mzr-workload-openshift
+  labels:
+    platform: ibm
+    code: 140
+  annotations:
+    displayName: MZR Workload VPC OpenShift
+    description: Multi-Zone Workload VPC with Red Hat OpenShift cluster and VPC Transit Gateway to Management VPC
 spec:
   modules:
     - name: ibm-resource-group
-      alias: hpcs_resource_group
+      alias: kms_resource_group
       variables:
         - name: provision
           value: false
-    - name: hpcs
-      alias: hpcs
+    - name: ibm-resource-group
+      alias: at_resource_group
+      variables:
+        - name: provision
+          value: false
+    - name: ibm-kms
+      alias: kms
       variables:
         - name: provision
           value: false
         - name: region
-          alias: hpcs_region
+          alias: kms_region
         - name: name_prefix
-          alias: hpcs_name_prefix
+          alias: kms_name_prefix
           scope: global
           value: ""
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: kms_resource_group
     - name: ibm-resource-group
       alias: mgmt_resource_group
       variables:
@@ -71,6 +82,8 @@ spec:
       alias: worker-subnets
       variables:
         - name: _count
+          alias: workload_worker_subnet_count
+          scope: global
           value: 3
         - name: label
           value: worker
@@ -89,6 +102,8 @@ spec:
           value: true
         - name: kms_enabled
           value: true
+        - name: worker_count
+          alias: workload_worker_count
       dependencies:
         - name: subnets
           ref: worker-subnets
@@ -157,14 +172,14 @@ spec:
           value: true
       dependencies:
         - name: kms
-          ref: hpcs
+          ref: kms
     - name: ibm-activity-tracker
       variables:
         - name: provision
           value: false
       dependencies:
         - name: resource_group
-          ref: hpcs_resource_group
+          ref: at_resource_group
     - name: sysdig
       variables:
         - name: provision
@@ -192,20 +207,6 @@ spec:
           ref: vpe-subnets
         - name: sync
           ref: cluster
-    - name: ibm-iam-service-authorization
-      alias: vsi-encrypt-auth
-      variables:
-        - name: source_service_name
-          value: server-protect
-        - name: target_service_name
-          value: hs-crypto
-        - name: roles
-          value: ["Reader"]
-      dependencies:
-        - name: source_resource_group
-          ref: resource_group
-        - name: target_resource_group
-          ref: hpcs_resource_group
     - name: ibm-transit-gateway
   variables:
     - name: workload_resource_group_name
@@ -232,3 +233,4 @@ spec:
     - name: workload_ssh_vpn_private_key_file
     - name: workload_ssh_bastion_public_key_file
     - name: workload_ssh_bastion_private_key_file
+    - name: kms_service

--- a/ref-arch/170-openshift-argocd.yaml
+++ b/ref-arch/170-openshift-argocd.yaml
@@ -8,9 +8,9 @@ spec:
       variables:
         - name: server_url
           required: true
-        - name: user
+        - name: login_user
           value: apikey
-        - name: password
+        - name: login_password
           alias: ibmcloud_api_key
           scope: global
     - name: namespace


### PR DESCRIPTION
Updates reference architectures to allow flexibility in footprint

- Replaces hpcs and key protect modules with ibm-kms module to provide a choice between key protect and hpcs
- Creates service authorizations for both hpcs and key protect
- Exposes worker_count variable as mgmt_worker_count and workload_worker_count to allow them to be configured independently
- Exposes worker-subnet__count variable as mgmt_worker_subnet_count and workload_worker_subnet_count to allow them to be configured independently
- Updates 170-openshift-argocd variable names to `login_user` and `login_password` (see #65)
- Updates BOMs with descriptive labels and annotations

Co-authored-by: Noé Samaille <noe.samaille@ibm.com>
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>