### PR TITLE
Fixes launch script in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "pkg": {
     "scripts": "dist/script.js",
     "assets": [
-      "dist/*",
       "dist/**/*",
-      "ref-arch/*"
+      "ref-arch/*",
+      "scripts/*"
     ],
     "targets": [
       "node14-linux-x64",
@@ -41,7 +41,7 @@
     "prepare": "npm run build",
     "prebuild": "rimraf dist",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --theme minimal src",
-    "postbuild": "chmod +x dist/lib/script*.js && cp -R ./scripts ./dist/",
+    "postbuild": "chmod +x dist/lib/script*.js",
     "start": "rollup -c rollup.config.ts -w",
     "test": "jest",
     "tdd": "jest --coverage --watch",

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -3,7 +3,7 @@
 # IBM Ecosystem Labs
 
 SCRIPT_DIR="$(cd $(dirname $0); pwd -P)"
-SRC_DIR="${SCRIPT_DIR}/terraform"
+SRC_DIR="${SCRIPT_DIR}"
 
 DOCKER_IMAGE="quay.io/ibmgaragecloud/cli-tools:v1.1"
 

--- a/src/commands/iascable-build.ts
+++ b/src/commands/iascable-build.ts
@@ -167,11 +167,19 @@ async function outputTile(rootPath: string, tile: Tile | undefined) {
 async function outputLaunchScript(rootPath: string) {
   await promises.mkdir(rootPath, {recursive: true})
 
-  return promises.copyFile(join(__dirname, '../../scripts', 'launch.sh'), join(rootPath, 'launch.sh'))
+  return promises.copyFile(join(getScriptsPath(), 'launch.sh'), join(rootPath, '../launch.sh'))
     .catch(() => {
       console.log('  Error writing launch script')
       return {}
     })
+}
+
+function getScriptsPath(): string {
+  if (new RegExp('dist/').test(__dirname)) {
+    return join(__dirname, '../../../scripts')
+  }
+
+  return join(__dirname, '../../scripts')
 }
 
 async function outputResult(rootPath: string, result: IascableResult): Promise<void> {


### PR DESCRIPTION
- Updates build process to pick up file
- Moves launch.sh to root ot output directory instead of BOM output dir

Co-authored-by: Noé Samaille <noe.samaille@ibm.com>
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>