### PR TITLE
Handles JSON parsing error of default values

### DIFF
--- a/src/services/catalog-loader/catalog-loader.impl.ts
+++ b/src/services/catalog-loader/catalog-loader.impl.ts
@@ -3,7 +3,7 @@ import {promises} from 'fs';
 import {default as superagent, Response} from 'superagent';
 import {JSON_SCHEMA, load} from 'js-yaml';
 
-import {Catalog, CatalogLoaderApi, CatalogModel, CatalogProviderModel} from './catalog-loader.api';
+import {Catalog, CatalogLoaderApi, CatalogProviderModel} from './catalog-loader.api';
 import {LoggerApi} from '../../util/logger';
 
 export class CatalogLoader implements CatalogLoaderApi {

--- a/src/services/terraform-builder/terraform-builder.new.ts
+++ b/src/services/terraform-builder/terraform-builder.new.ts
@@ -187,7 +187,15 @@ function defaultValue(variable: ModuleVariable, bomModule?: BillOfMaterialModule
     .map(v => v.value)
     .orElseGet(() => {
       if (isDefinedAndNotNull(variable)) {
-        return variable.default;
+        if (variable.type !== 'string' && typeof variable.default === 'string') {
+          try {
+            return JSON.parse(variable.default);
+          } catch (err) {
+            return variable.default;
+          }
+        } else {
+          return variable.default;
+        }
       }
 
       return variable.defaultValue;


### PR DESCRIPTION
- Applies JSON.parse() on variable default values if the variable type is not string but the value is a string

closes #73

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>