### PR TITLE
Adds support for multiple input BOMs in one call

### DIFF
--- a/src/commands/inputs/iascable.input.ts
+++ b/src/commands/inputs/iascable.input.ts
@@ -1,14 +1,12 @@
 
 export interface IascableInput {
   catalogUrl: string;
-  input?: string;
-  reference?: string;
-  ci: boolean;
-  prompt: boolean;
+  input?: string[];
+  reference?: string[];
   platform?: string;
   provider?: string;
   tileLabel?: string;
-  name: string;
+  name?: string[];
   tileDescription?: string;
   outDir?: string;
 }

--- a/src/services/iascable.api.ts
+++ b/src/services/iascable.api.ts
@@ -16,4 +16,5 @@ export interface IascableOptions {
 
 export abstract class IascableApi {
   abstract build(catalogUrl: string, input?: BillOfMaterialModel, options?: IascableOptions): Promise<IascableResult>;
+  abstract buildBoms(catalogUrl: string, input: BillOfMaterialModel[], options?: IascableOptions): Promise<IascableResult[]>;
 }


### PR DESCRIPTION
- The `-i` or `-r` and `--name` arguments can be provided multiple times to generate terraform from multiple BOMs at one time. E.g.

    ```shell
    isacable -i ./bom1.yaml -i bom2.yaml -o myoutput
    ```

- Removes arguments for interactive mode of the cli

closes #149

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>