### PR TITLE
Adds support for path annotation in BOM

### DIFF
--- a/examples/baseline-ocp2.yaml
+++ b/examples/baseline-ocp2.yaml
@@ -2,6 +2,8 @@ apiVersion: cloud.ibm.com/v1alpha1
 kind: BillOfMaterial
 metadata:
   name: baseline-ocp-vpc2
+  annotations:
+    path: test
 spec:
   modules:
     - name: ibm-ocp-vpc

--- a/src/commands/iascable-build.ts
+++ b/src/commands/iascable-build.ts
@@ -108,9 +108,8 @@ export const handler = async (argv: Arguments<IascableInput & CommandLineInput &
     console.log(`Writing output to: ${outputDir}`)
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
-      const name = result.billOfMaterial.metadata?.name || 'component';
 
-      await outputResult(join(outputDir, name), result, argv.flattenOutput);
+      await outputResult(buildRootPath(outputDir, result.billOfMaterial), result, argv.flattenOutput);
     }
   } catch (err) {
     console.log('')
@@ -121,6 +120,17 @@ export const handler = async (argv: Arguments<IascableInput & CommandLineInput &
     }
   }
 };
+
+const buildRootPath = (outputDir: string, bom: BillOfMaterialModel): string => {
+  const pathParts: string[] = [
+    outputDir,
+    bom.metadata?.annotations?.path || '',
+    bom.metadata?.name || 'component'
+  ]
+    .filter(v => !!v)
+
+  return join(...pathParts)
+}
 
 async function loadBoms(referenceNames?: string[], inputNames?: string[], names: string[] = []): Promise<Array<BillOfMaterialModel>> {
   const boms: Array<BillOfMaterialModel> = [];


### PR DESCRIPTION
The `path` annotation puts the generated terraform in a path relative to the `output` folder. 

For example:

```yaml
apiVersion: cloud.ibm.com/v1alpha1
kind: BillOfMaterial
metadata:
  name: baseline-ocp-vpc2
  annotations:
    path: test
spec:
  modules:
    - name: ibm-ocp-vpc
    - name: openshift-cicd
  variables: []
```

Because of the `path: test` annotation, this BOM will output the generated terraform into a folder named `{output dir}/test/baseline-ocp-vpc2` instead of `{output dir}/baseline-ocp-vpc2` as it would by default.

This example is also provided in `examples/baseline-ocp2.yaml`

closes #166 

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>