### PR TITLE
quick and dirty fix

### DIFF
--- a/examples/rg-redirect.yaml
+++ b/examples/rg-redirect.yaml
@@ -1,0 +1,9 @@
+apiVersion: cloud.ibm.com/v1alpha1
+kind: BillOfMaterial
+metadata:
+  name: component
+spec:
+  modules:
+    #- github.com/cloud-native-toolkit/terraform-ibm-resource-group
+    - github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group
+  variables: []

--- a/migrated-modules.json
+++ b/migrated-modules.json
@@ -1,0 +1,5 @@
+{
+  "github.com/cloud-native-toolkit/terraform-ibm-resource-group": [
+    "github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group"
+  ]
+}

--- a/src/models/catalog.model.ts
+++ b/src/models/catalog.model.ts
@@ -186,6 +186,8 @@ const cleanId = (id?: string): string => {
 
 
 const getResolvedId = (id:string): string => {
+  id = cleanId(id);
+
   let hasKeys = false;
   for (const key in idMap) {
     if (idMap.hasOwnProperty(key)) {


### PR DESCRIPTION
Quick and dirty fix for https://github.com/cloud-native-toolkit/software-everywhere/issues/366
This uses an embedded json file for the migrated modules.  Ideal solution should pull redirect mappings from the catalog.

Signed-off-by: Andrew Trice <amtrice@us.ibm.com>