### PR TITLE
Handles relocated modules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,28 @@ jobs:
           npm install -g pkg
           npm run pkg
 
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Setup directory
+        run: |
+          mkdir -p public
+          cp install.sh public
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          cname: iascable.cloudnativetoolkit.dev
+
   release:
     if: ${{ github.event_name == 'push' }}
     needs: verify

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ modules.
 To install the latest version of iascable into `/usr/local/bin`, run the following:
 
 ```shell
-curl -sL https://raw.githubusercontent.com/cloud-native-toolkit/iascable/main/install.sh | sh
+curl -sL https://iasable.cloudnativetoolkit.dev/install.sh | sh
 ```
 
 If you would like to install a different version of the CLI and/or put it in a different directory, use the following:
 
 ```shell
-curl -sL https://raw.githubusercontent.com/cloud-native-toolkit/iascable/main/install.sh | RELEASE=2.8.1 DEST_DIR=~/bin sh
+curl -sL https://iasable.cloudnativetoolkit.dev/install.sh | RELEASE=2.8.1 DEST_DIR=~/bin sh
 ```
 
 ### Commands

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "prepare": "npm run build",
-    "prebuild": "rimraf dist",
+    "clean": "rimraf dist",
+    "prebuild": "npm run clean",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --theme minimal src",
     "postbuild": "chmod +x dist/lib/script*.js && cp -R ./scripts ./dist",
     "start": "rollup -c rollup.config.ts -w",

--- a/src/models/catalog.model.spec.ts
+++ b/src/models/catalog.model.spec.ts
@@ -28,6 +28,17 @@ describe('catalog model', () => {
       });
     });
 
+    describe('when called with an old id', () => {
+      test('then it should return a module', async () => {
+        const id = 'github.com/cloud-native-toolkit/terraform-ibm-resource-group';
+        const expectedId = 'github.com/terraform-ibm-modules/terraform-ibm-resource-group'
+
+        const actualResult = classUnderTest.lookupModule({id});
+        expect(actualResult).toBeDefined();
+        expect(actualResult?.id).toBe(expectedId);
+      });
+    });
+
     describe('when called with a valid name', () => {
       test('then it should return a module', async () => {
         const name = 'ibm-container-platform';

--- a/src/models/module.model.ts
+++ b/src/models/module.model.ts
@@ -27,6 +27,7 @@ export interface ModuleTemplate {
   id: string;
   registryId?: string;
   name: string;
+  idAliases?: string[];
   alias?: string;
   default?: boolean;
   originalAlias?: string;

--- a/src/moduleIdAliases.yaml
+++ b/src/moduleIdAliases.yaml
@@ -1,0 +1,4 @@
+moduleIds:
+  - id: github.com/terraform-ibm-modules/terraform-ibm-toolkit-resource-group
+    aliases:
+      - github.com/cloud-native-toolkit/terraform-ibm-resource-group

--- a/src/services/catalog-loader/catalog-loader.impl.ts
+++ b/src/services/catalog-loader/catalog-loader.impl.ts
@@ -3,7 +3,11 @@ import {promises} from 'fs';
 import {default as superagent, Response} from 'superagent';
 import {JSON_SCHEMA, load} from 'js-yaml';
 
-import {Catalog, CatalogLoaderApi, CatalogProviderModel} from './catalog-loader.api';
+import {
+  Catalog,
+  CatalogLoaderApi,
+  CatalogProviderModel
+} from './catalog-loader.api';
 import {LoggerApi} from '../../util/logger';
 
 export class CatalogLoader implements CatalogLoaderApi {

--- a/src/services/module-selector/selected-modules.resolver.spec.ts
+++ b/src/services/module-selector/selected-modules.resolver.spec.ts
@@ -9,11 +9,21 @@ import {
 import {Container} from 'typescript-ioc';
 import {LoggerApi} from '../../util/logger';
 import {consoleLoggerFactory, LogLevel} from '../../util/logger/console-logger.impl';
+import {NoopLoggerImpl} from '../../util/logger/noop-logger.impl';
+import {CatalogLoaderApi} from '../catalog-loader';
 
 describe('selected-modules.resolver', () => {
   test('canary verifies test infrastructure', () => {
     expect(true).toBe(true)
   })
+
+  let catalog: Catalog;
+  beforeAll(async () => {
+    Container.bind(LoggerApi).to(NoopLoggerImpl);
+
+    const catalogLoader: CatalogLoaderApi = Container.get(CatalogLoaderApi);
+    catalog = await catalogLoader.loadCatalog(`file:/${process.cwd()}/test/catalog.yaml`)
+  });
 
   describe('given updateAliasForDuplicateModules()', () => {
     describe('when the same module appears twice', () => {
@@ -132,7 +142,7 @@ describe('selected-modules.resolver', () => {
       })
 
       test('then return true', async () => {
-        expect(matchRefs(dep, module)).toBe(true);
+        expect(matchRefs(dep, module, catalog)).toBe(true);
       });
     });
 
@@ -155,7 +165,7 @@ describe('selected-modules.resolver', () => {
       })
 
       test('then return false', async () => {
-        expect(matchRefs(dep, module)).toBe(false);
+        expect(matchRefs(dep, module, catalog)).toBe(false);
       })
     })
   })

--- a/test/catalog.yaml
+++ b/test/catalog.yaml
@@ -16,6 +16,10 @@ providers:
         moduleRef:
           id: clis
           output: bin_dir
+aliases:
+  - id: github.com/terraform-ibm-modules/terraform-ibm-resource-group
+    aliases:
+      - github.com/cloud-native-toolkit/terraform-ibm-resource-group
 categories:
   - category: ai-ml
     categoryName: AI/ML
@@ -29879,7 +29883,7 @@ categories:
       - cloudProvider: ibm
         softwareProvider: ""
         type: terraform
-        id: github.com/cloud-native-toolkit/terraform-ibm-resource-group
+        id: github.com/terraform-ibm-modules/terraform-ibm-resource-group
         name: ibm-resource-group
         alias: resource_group
         description: Creates a resource groups in the account


### PR DESCRIPTION
- Adds support for aliases entry in catalog with mapping from current id to previous ids
- Adds workflow job to publish install.sh to gh-pages
- Updates readme with simplified install steps

closes cloud-native-toolkit/software-everywhere#366

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>