### PR TITLE
Fixes issues installing back-level versions of cli

### DIFF
--- a/.github/workflows/asset-publish.yaml
+++ b/.github/workflows/asset-publish.yaml
@@ -41,6 +41,17 @@ jobs:
           asset_name: iascable-linux-x64
           asset_content_type: application/octet-stream
 
+      - name: Upload Linux cli
+        id: upload-linux-cli
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./iascable-linux-x64
+          asset_name: iascable-linux
+          asset_content_type: application/octet-stream
+
       - name: Upload Linux arm64 cli
         id: upload-linux-arm64-cli
         uses: actions/upload-release-asset@v1
@@ -63,6 +74,17 @@ jobs:
           asset_name: iascable-macos-x64
           asset_content_type: application/octet-stream
 
+      - name: Upload MacOS cli
+        id: upload-macos-cli
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./iascable-macos-x64
+          asset_name: iascable-macos
+          asset_content_type: application/octet-stream
+
       - name: Upload MacOS arm64 cli
         id: upload-macos-arm64-cli
         uses: actions/upload-release-asset@v1
@@ -83,6 +105,17 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./iascable-alpine-x64
           asset_name: iascable-alpine-x64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Alpine cli
+        id: upload-alpine-cli
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./iascable-alpine-x64
+          asset_name: iascable-alpine
           asset_content_type: application/octet-stream
 
       - name: Upload Alpine arm64 cli

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ curl -sL https://iascable.cloudnativetoolkit.dev/install.sh | sh
 If you would like to install a different version of the CLI and/or put it in a different directory, use the following:
 
 ```shell
-curl -sL https://iascable.cloudnativetoolkit.dev/install.sh | RELEASE=2.8.1 DEST_DIR=~/bin sh
+curl -sL https://iascable.cloudnativetoolkit.dev/install.sh | RELEASE=2.15.1 DEST_DIR=~/bin sh
 ```
 
 ### Commands

--- a/install.sh
+++ b/install.sh
@@ -32,13 +32,13 @@ fi
 
 ARCH=""
 case $(uname -m) in
-    i386)    ARCH="x64" ;;
-    i686)    ARCH="x64" ;;
-    x86_64)  ARCH="x64" ;;
-    aarch64) ARCH="arm64" ;;
-    arm64)   ARCH="arm64" ;;
+    i386)    ARCH="" ;;
+    i686)    ARCH="" ;;
+    x86_64)  ARCH="" ;;
+    aarch64) ARCH="-arm64" ;;
+    arm64)   ARCH="-arm64" ;;
     *)       echo "Unable to determine system architecture" >&2; exit 1 ;;
 esac
 
-echo "Installing version ${RELEASE} of iascable for ${TYPE}-${ARCH} into ${DEST_DIR}"
-curl --progress-bar -Lo "${DEST_DIR}/iascable" "https://github.com/cloud-native-toolkit/iascable/releases/download/${RELEASE}/iascable-${TYPE}-${ARCH}" && chmod +x "${DEST_DIR}/iascable"
+echo "Installing version ${RELEASE} of iascable for ${TYPE}${ARCH} into ${DEST_DIR}"
+curl --progress-bar -Lo "${DEST_DIR}/iascable" "https://github.com/cloud-native-toolkit/iascable/releases/download/${RELEASE}/iascable-${TYPE}${ARCH}" && chmod +x "${DEST_DIR}/iascable"


### PR DESCRIPTION
- Updates asset names and install.sh to be backwards compatable - closes #181

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>