### PR TITLE
ignore error when reading private repo readme

### DIFF
--- a/src/models/file.model.ts
+++ b/src/models/file.model.ts
@@ -26,9 +26,12 @@ export class UrlFile implements OutputFile {
 
   get contents(): Promise<string | Buffer> {
     return new Promise<string>(async (resolve) => {
-      const req: superagent.Response = await superagent.get(this.url);
-
-      resolve(req.text);
-    });
+      try {
+        const res = await superagent.get(this.url);
+        resolve(res.text)
+      } catch (err) {
+        resolve("README.md could not be read. Private repo?")
+      }
+    })
   }
 }

--- a/src/models/file.model.ts
+++ b/src/models/file.model.ts
@@ -17,21 +17,19 @@ export class UrlFile implements OutputFile {
   name: string;
   url: string;
   type?: OutputFileType;
+  _alternative: () => Promise<string | Buffer>;
 
-  constructor({name, url, type}: {name: string, url: string, type?: OutputFileType}) {
+  constructor({name, url, type, alternative = () => Promise.resolve('')}: {name: string, url: string, type?: OutputFileType, alternative?: () => Promise<string | Buffer>}) {
     this.name = name;
     this.url = url;
     this.type = type;
+    this._alternative = alternative;
   }
 
   get contents(): Promise<string | Buffer> {
-    return new Promise<string>(async (resolve) => {
-      try {
-        const res = await superagent.get(this.url);
-        resolve(res.text)
-      } catch (err) {
-        resolve("README.md could not be read. Private repo?")
-      }
-    })
+    return superagent
+      .get(this.url)
+      .then(res => res.text)
+      .catch(() => this._alternative())
   }
 }

--- a/src/services/iascable.impl.ts
+++ b/src/services/iascable.impl.ts
@@ -81,7 +81,7 @@ export class CatalogBuilder implements IascableApi {
 
     const billOfMaterial: BillOfMaterialModel = applyVersionsToBomModules(bom, modules);
 
-    const terraformComponent: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules, billOfMaterial, catalog);
+    const terraformComponent: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules, catalog, billOfMaterial);
 
     const tile: Tile | undefined = options?.tileConfig ? await this.tileBuilder.buildTileMetadata(terraformComponent.baseVariables, options.tileConfig) : undefined;
 

--- a/src/services/module-documentation/module-documentation.ts
+++ b/src/services/module-documentation/module-documentation.ts
@@ -140,7 +140,7 @@ ${modules}
   async example(module: Module, catalog: Catalog): Promise<string> {
     const modules: SingleModuleVersion[] = new SelectedModuleResolverImpl(catalog).resolve([module])
 
-    const terraform: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules, undefined, catalog)
+    const terraform: TerraformComponent = await this.terraformBuilder.buildTerraformComponent(modules, catalog)
 
     const currentStage: Stage[] = Object.values(terraform.stages).filter(stage => stage.source === module.id)
 

--- a/src/services/terraform-builder/terraform-buiilder.impl.spec.ts
+++ b/src/services/terraform-builder/terraform-buiilder.impl.spec.ts
@@ -57,7 +57,7 @@ describe('terraform-builder', () => {
       });
 
       test('then use the module defined by the alias', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         expect(Object.keys(result.stages).length).toEqual(4);
 
@@ -90,7 +90,7 @@ describe('terraform-builder', () => {
       });
 
       test('then apply the variables to the resulting terraform module', async () => {
-        const result = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         const variableName = result.stages['tools-namespace'].variables.filter(v => v.name === 'name').map(v => (v as GlobalRefVariable).variableName)[0];
         const variables = result.baseVariables.filter(v => v.name === variableName).map(v => v.defaultValue);
@@ -114,7 +114,7 @@ describe('terraform-builder', () => {
       });
 
       test('then return all matching dependent modules', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         expect(Object.keys(result.stages).length).toEqual(4);
 
@@ -144,7 +144,7 @@ describe('terraform-builder', () => {
       });
 
       test('then associate optional dependent module', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         expect(Object.keys(result.stages).length).toEqual(4);
 
@@ -172,7 +172,7 @@ describe('terraform-builder', () => {
       });
 
       test('then do not associate optional dependent module', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         expect(Object.keys(result.stages).length).toEqual(3);
 
@@ -200,7 +200,7 @@ describe('terraform-builder', () => {
       });
 
       test('then the variable should appear in terraform.tfvars', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         const tfvarsFile: Optional<TerraformTfvarsFile> = arrayOf(result.files).filter(f => f.name === 'terraform.tfvars').first() as any
 
@@ -224,7 +224,7 @@ describe('terraform-builder', () => {
       });
 
       test('then result should include provider modules', async () => {
-        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules);
+        const result: TerraformComponent = await classUnderTest.buildTerraformComponent(selectedModules, catalog);
 
         expect(result.stages['clis']).toBeDefined()
         expect(result.providers?.length).toEqual(1)

--- a/src/services/terraform-builder/terraform-builder.api.ts
+++ b/src/services/terraform-builder/terraform-builder.api.ts
@@ -6,5 +6,5 @@ import {
 } from '../../models';
 
 export abstract class TerraformBuilderApi {
-  abstract buildTerraformComponent(modules: SingleModuleVersion[], billOfMaterial?: BillOfMaterialModel, catalogModel?: CatalogModel): Promise<TerraformComponent>;
+  abstract buildTerraformComponent(modules: SingleModuleVersion[], catalogModel: CatalogModel, billOfMaterial?: BillOfMaterialModel): Promise<TerraformComponent>;
 }

--- a/src/services/terraform-builder/terraform-builder.new.ts
+++ b/src/services/terraform-builder/terraform-builder.new.ts
@@ -5,7 +5,7 @@ import {
   BillOfMaterialModule,
   BillOfMaterialModuleVariable,
   BillOfMaterialProvider,
-  BillOfMaterialVariable,
+  BillOfMaterialVariable, CatalogModel,
   IBaseVariable,
   IPlaceholderVariable,
   isPlaceholderVariable,
@@ -67,7 +67,7 @@ const buildProviderId = (provider: {name: string, alias?: string}): string => {
 }
 
 export class TerraformBuilderNew implements TerraformBuilderApi {
-  async buildTerraformComponent(modules: SingleModuleVersion[], billOfMaterial?: BillOfMaterialModel): Promise<TerraformComponent> {
+  async buildTerraformComponent(modules: SingleModuleVersion[], catalog: CatalogModel, billOfMaterial?: BillOfMaterialModel): Promise<TerraformComponent> {
 
     const terraform: TerraformResult = modules.reduce(
       (result: TerraformResult, module: SingleModuleVersion) => {
@@ -102,7 +102,8 @@ export class TerraformBuilderNew implements TerraformBuilderApi {
       modules,
       bomVariables: billOfMaterial?.spec.variables,
       billOfMaterial,
-      files: []
+      files: [],
+      catalog
     }, name);
   }
 


### PR DESCRIPTION
When using a private repo on github.com, iascable cannot read README.md since it requires a GitHub token. Since the README.md is only downloaded to copy the documentation, I changed the code to ignore the error and continue with the output directory creation.