### PR TITLE
keep leading slash in catalog file path

### DIFF
--- a/src/services/catalog-loader/catalog-loader.impl.ts
+++ b/src/services/catalog-loader/catalog-loader.impl.ts
@@ -41,7 +41,7 @@ export class CatalogLoader implements CatalogLoaderApi {
   async loadCatalogYaml(catalogUrls: string[]): Promise<CatalogModel> {
 
     const catalogYamls: string[] = await Promise.all(catalogUrls.map(catalogUrl => catalogUrl.startsWith('file:/')
-      ? this.loadCatalogFromFile(catalogUrl.replace('file:/', ''))
+      ? this.loadCatalogFromFile(catalogUrl.replace('file:', ''))
       : this.loadCatalogFromUrl(catalogUrl)
     ))
 


### PR DESCRIPTION
Avoids removing leading `/` in a path provided to a catalog before reading the file.

fixes #225 

Signed-off-by: Tim Robinson <timroster@gmail.com>