### PR TITLE
Adds support for module metadata as catalog input

### DIFF
--- a/src/models/crd.model.ts
+++ b/src/models/crd.model.ts
@@ -1,0 +1,5 @@
+
+export interface CustomResourceDefinition {
+  apiVersion?: string;
+  kind?: string;
+}

--- a/src/models/module.model.ts
+++ b/src/models/module.model.ts
@@ -4,6 +4,7 @@ import {isUndefined} from '../util/object-util';
 import {ArrayUtil, of as arrayOf} from '../util/array-util/array-util';
 import {Optional} from '../util/optional';
 import {CatalogProviderModel} from './catalog.model';
+import {CustomResourceDefinition} from './crd.model';
 
 export interface ModuleProvider {
   name: string;
@@ -23,7 +24,7 @@ export interface ModuleMatcher {
   version: VersionMatcher[];
 }
 
-export interface ModuleTemplate {
+export interface ModuleTemplate extends CustomResourceDefinition {
   id: string;
   registryId?: string;
   name: string;

--- a/src/services/module-selector/module-selector.impl.spec.ts
+++ b/src/services/module-selector/module-selector.impl.spec.ts
@@ -5,7 +5,7 @@ import {
   BillOfMaterialModel,
   BillOfMaterialModule,
   BillOfMaterialModuleDependency,
-  Catalog,
+  Catalog, catalogApiVersion, catalogKind,
   CatalogModel,
   SingleModuleVersion
 } from '../../models';
@@ -268,6 +268,8 @@ describe('module-selector', () => {
 
   describe('given validateBillOfMaterialModuleConfigYaml()', () => {
     const testCatalog: CatalogModel = {
+      apiVersion: catalogApiVersion,
+      kind: catalogKind,
       categories: [{
         category: 'test',
         selection: 'multiple',

--- a/src/services/module-selector/selected-modules.resolver.spec.ts
+++ b/src/services/module-selector/selected-modules.resolver.spec.ts
@@ -1,4 +1,11 @@
-import {BillOfMaterialModule, Catalog, Module, ModuleDependency} from '../../models';
+import {
+  BillOfMaterialModule,
+  Catalog,
+  catalogApiVersion,
+  catalogKind,
+  Module,
+  ModuleDependency
+} from '../../models';
 import {
   getModuleKey,
   matchInterface,
@@ -283,6 +290,8 @@ describe('selected-modules.resolver', () => {
       }] as any
 
       catalog = new Catalog({
+        apiVersion: catalogApiVersion,
+        kind: catalogKind,
         providers: [{
           name: 'gitops',
           source: 'cloud-native-toolkit/gitops',

--- a/test/catalog.yaml
+++ b/test/catalog.yaml
@@ -1,3 +1,5 @@
+apiVersion: cloudnativetoolkit.dev/v1alpha1
+kind: Catalog
 providers:
   - name: ibm
     source: ibm-cloud/ibm


### PR DESCRIPTION
- Allows module metadata file to be passed as input for catalog url instead of requiring a full catalog

closes #212

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>