### PR TITLE
Updates catalogUrls to include base catalog by default

### DIFF
--- a/src/commands/iascable-build.ts
+++ b/src/commands/iascable-build.ts
@@ -25,6 +25,7 @@ import {
 import {LoggerApi} from '../util/logger';
 import {DotGraphFile} from '../models/graph.model';
 import {chmodRecursive} from '../util/file-util';
+import {DEFAULT_CATALOG_URL, setupCatalogUrls} from './support/middleware';
 
 export const command = 'build';
 export const desc = 'Configure (and optionally deploy) the iteration zero assets';
@@ -34,7 +35,7 @@ export const builder = (yargs: Argv<any>) => {
       alias: 'c',
       type: 'array',
       description: 'The url of the module catalog. Can be https:// or file:/ protocol. This argument can be passed multiple times to include multiple catalogs.',
-      default: 'https://modules.cloudnativetoolkit.dev/index.yaml'
+      default: DEFAULT_CATALOG_URL
     })
     .option('input', {
       alias: 'i',
@@ -87,6 +88,7 @@ export const builder = (yargs: Argv<any>) => {
       type: 'boolean',
       describe: 'Flag to turn on more detailed output message',
     })
+    .middleware(setupCatalogUrls(DEFAULT_CATALOG_URL))
     .check((argv) => {
       if (!(argv.reference && argv.reference.length > 0) && !(argv.input && argv.input.length > 0)) {
         throw new Error('Bill of Materials not provided. Provide the path to the bill of material file with the -i or -r flag.')

--- a/src/commands/iascable-docs.ts
+++ b/src/commands/iascable-docs.ts
@@ -8,6 +8,7 @@ import {IascableDocsInput} from './inputs/iascable.input';
 import {ModuleDoc} from '../models';
 import {IascableApi} from '../services';
 import {LoggerApi} from '../util/logger';
+import {DEFAULT_CATALOG_URL, setupCatalogUrls} from './support/middleware';
 
 export const command = 'docs [module]';
 export const desc = 'Produces the documentation for a given module';
@@ -35,6 +36,7 @@ export const builder = (yargs: Argv<any>) => {
       default: false,
       type: 'boolean'
     })
+    .middleware(setupCatalogUrls(DEFAULT_CATALOG_URL))
     .option('debug', {
       type: 'boolean',
       describe: 'Flag to turn on more detailed output message',

--- a/src/commands/support/middleware.ts
+++ b/src/commands/support/middleware.ts
@@ -1,0 +1,20 @@
+
+export const DEFAULT_CATALOG_URL = 'https://modules.cloudnativetoolkit.dev/index.yaml'
+
+export const setupCatalogUrls = (defaultCatalogUrl: string = DEFAULT_CATALOG_URL) => {
+  return (yargs: any) => {
+    const result: {catalogUrls?: string[]} = {}
+
+    const catalogUrls: string[] | undefined = yargs.catalogUrls
+
+    if (catalogUrls && !catalogUrls.includes(defaultCatalogUrl)) {
+      const newCatalogUrls: string[] = [defaultCatalogUrl]
+
+      newCatalogUrls.push(...catalogUrls)
+
+      result.catalogUrls = newCatalogUrls
+    }
+
+    return result
+  }
+}


### PR DESCRIPTION
- The default catalog url (https://modules.cloudnativetoolkit.dev/index.yaml) is added as the first catalog in the list if it is not explicitly provided as input

closes #231

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>