### PR TITLE
Fixes error generating documentation if lookup fails

### DIFF
--- a/src/commands/iascable-build.ts
+++ b/src/commands/iascable-build.ts
@@ -237,7 +237,7 @@ async function outputTerraform(rootPath: string, terraformComponent: TerraformCo
 
       promiseList.push(result)
     } catch (err) {
-      logger.warn(`Unable to generate file: ${file.name}`)
+      logger.warn(`Warning: Unable to generate file ${file.name}`)
       logger.debug('  Error: ', err)
     }
   }

--- a/src/models/stages.model.ts
+++ b/src/models/stages.model.ts
@@ -277,7 +277,7 @@ function buildModuleReadmes(catalog: CatalogModel, modules: SingleModuleVersion[
       type: OutputFileType.documentation,
       url,
       alternative: async () => {
-        const readme = await docService.generateDocumentation(fullModule, catalog)
+        const readme = await docService.generateDocumentation(fullModule, catalog, modules)
 
         return readme.contents
       }

--- a/src/services/module-documentation/module-documentation.api.ts
+++ b/src/services/module-documentation/module-documentation.api.ts
@@ -1,5 +1,5 @@
-import {CatalogModel, Module, ModuleDoc} from '../../models';
+import {CatalogModel, Module, ModuleDoc, SingleModuleVersion} from '../../models';
 
 export abstract class ModuleDocumentationApi {
-  abstract generateDocumentation(module: Module, catalog: CatalogModel): Promise<ModuleDoc>;
+  abstract generateDocumentation(module: Module, catalog: CatalogModel, moduleList?: SingleModuleVersion[]): Promise<ModuleDoc>;
 }


### PR DESCRIPTION
- Passes existing list of BOM modules to generation logic instead of trying to regenerate the list

closes #230

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>