### PR TITLE
Fixes catalog logic to ensure custom modules override base catalog

### DIFF
--- a/src/models/stages.model.ts
+++ b/src/models/stages.model.ts
@@ -348,7 +348,7 @@ export class StageImpl implements Stage, StagePrinter {
 ${version}`
     }
 
-    const urlRef = this.module.version.version ? `?ref=${this.module.version.version}` : ''
+    const urlRef = this.module.version.version && !this.module.id.startsWith('file:') ? `?ref=${this.module.version.version}` : ''
     return `${indent}source = "${this.module.id}${urlRef}"`
   }
 

--- a/src/services/catalog-loader/catalog-loader.impl.ts
+++ b/src/services/catalog-loader/catalog-loader.impl.ts
@@ -57,7 +57,7 @@ export class CatalogLoader implements CatalogLoaderApi {
 
       const newModel: CatalogModel = isCatalogKind(inputYaml) ? inputYaml : catalogFromModule(inputYaml)
 
-      return mergeCatalogs(newModel, result)
+      return mergeCatalogs(result, newModel)
     }, {} as any)
   }
 
@@ -92,8 +92,8 @@ const mergeCatalogs = (baseCatalog: CatalogModel, newCatalog: CatalogModel): Cat
 
         const aliases = _.uniqBy((current.aliases || []).concat(result.aliases || []), 'id')
         const providers = _.uniqBy((current.providers || []).concat(result.providers || []), 'name')
-        const modules = _.uniqBy(getFlattenedModules(current).concat(result.modules || []), 'id')
-        const boms = _.uniqBy(getBoms(current).concat(result.boms || []), 'id')
+        const modules = _.uniqBy(getFlattenedModules(current).concat(result.modules || []), 'name')
+        const boms = _.uniqBy(getBoms(current).concat(result.boms || []), 'name')
 
         return {kind: catalogKind, apiVersion: catalogApiV2Version, aliases, providers, modules, boms}
       },


### PR DESCRIPTION
- Uses 'name' attribute to test module uniqueness in catalog instead of id
- Puts new modules before existing catalog modules in list so new modules are selected when there are duplicates
- Removes '?ref={version}' if the id is a 'file:' url

closes #240

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>