### PR TITLE
Fix bundle writing when optional basePath not provided

### DIFF
--- a/src/services/iascable/iascable.impl.ts
+++ b/src/services/iascable/iascable.impl.ts
@@ -648,7 +648,7 @@ const writeFilesWithWriter = (writer: BundleWriter, options?: {flatten?: boolean
 }
 
 const writeFile = (writer: BundleWriter, file: OutputFile, options: {flatten?: boolean, basePath: string} = {flatten: false, basePath: '.'}) => {
-  const fileOptions: {flatten?: boolean, path: string} = Object.assign({}, options, {path: join(options?.basePath, writer.getPath())})
+  const fileOptions: {flatten?: boolean, path: string} = Object.assign({}, options, {path: join(options?.basePath || '.', writer.getPath())})
 
   writer.file(
     file.name,


### PR DESCRIPTION
- Default basePath to '.' if not provided - closes #307